### PR TITLE
Rename ServiceInterceptor and add status_on_unknown_exception to ExceptionToStatusInterceptor

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,7 @@
 [flake8]
 select = B,B9,C,D,E,F,I,S,W
 exclude = *_pb2.py,*_pb2_grpc.py
+ignore = D107,W503
 
 application-import-names = grpc_interceptor,tests
 import-order-style = google

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,5 @@
 name: Coverage
-on: push
+on: [push, pull_request]
 jobs:
     coverage:
         runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Tests
-on: push
+on: [push, pull_request]
 jobs:
     tests:
         strategy:

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ $ pip install grpc-interceptor[testing]
 To define your own interceptor (we can use `ExceptionToStatusInterceptor` as an example):
 
 ```python
-from grpc_interceptor.base import Interceptor
+from grpc_interceptor.base import ServiceInterceptor
 
-class ExceptionToStatusInterceptor(Interceptor):
+class ExceptionToStatusInterceptor(ServiceInterceptor):
     def intercept(
         self,
         method: Callable,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,8 @@
 """Sphinx configuration."""
+
+import re
+
+
 project = "grpc-interceptor"
 author = "Dan Hipschman"
 copyright = f"2020, {author}"
@@ -6,3 +10,15 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
 ]
+
+
+def setup(app):
+    """Sphinx setup."""
+    app.connect("autodoc-skip-member", skip_member)
+
+
+def skip_member(app, what, name, obj, skip, options):
+    """Ignore ugly auto-generated doc strings from namedtuple."""
+    doc = getattr(obj, "__doc__", "") or ""  # Handle when __doc__ is missing on None
+    is_namedtuple_docstring = bool(re.fullmatch("Alias for field number [0-9]+", doc))
+    return is_namedtuple_docstring or skip

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,7 +25,7 @@ dependencies to a minimum. The only core dependency is the ``grpc`` package, and
 
 The ``grpc_interceptor`` package provides the following:
 
-* An ``Interceptor`` base class, to make it easy to define your own service interceptors.
+* A ``ServiceInterceptor`` base class, to make it easy to define your own service interceptors.
 * An ``ExceptionToStatusInterceptor`` interceptor, so your service can raise exceptions
   that set the gRPC status code correctly (rather than the default of every exception
   resulting in an ``UNKNOWN`` status code). This is something for which pretty much any
@@ -50,13 +50,14 @@ To also install the testing framework:
 Usage
 -----
 
-To define your own interceptor (we can use ``ExceptionToStatusInterceptor`` as an example):
+To define your own interceptor (we can use a simplified version of
+``ExceptionToStatusInterceptor`` as an example):
 
 .. code-block:: python
 
    from grpc_interceptor.base import Interceptor
 
-   class ExceptionToStatusInterceptor(Interceptor):
+   class ExceptionToStatusInterceptor(ServiceInterceptor):
 
        def intercept(
            self,
@@ -161,5 +162,5 @@ Limitations
 These are the current limitations, although supporting these is possible. Contributions
 or requests are welcome.
 
-* ``Interceptor`` currently only supports unary-unary RPCs.
+* ``ServiceInterceptor`` currently only supports unary-unary RPCs.
 * The package only provides service interceptors.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -22,3 +22,9 @@ grpc_interceptor.exceptions
 
 .. automodule:: grpc_interceptor.exceptions
    :members:
+
+grpc_interceptor.testing
+------------------------------------
+
+.. automodule:: grpc_interceptor.testing
+   :members:

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 import nox
 
 
-nox.options.sessions = "lint", "mypy", "safety", "tests"
+nox.options.sessions = "lint", "mypy", "safety", "tests", "xdoctest"
 
 
 @nox.session(python=["3.8", "3.7", "3.6"])
@@ -20,6 +20,15 @@ def tests(session):
         session, "coverage[toml]", "grpcio-tools", "pytest", "pytest-cov"
     )
     session.run("pytest", *args)
+
+
+@nox.session(python=["3.8", "3.7", "3.6"])
+def xdoctest(session) -> None:
+    """Run examples with xdoctest."""
+    args = session.posargs or ["all"]
+    session.run("poetry", "install", "--no-dev", external=True)
+    install_with_constraints(session, "xdoctest")
+    session.run("python", "-m", "xdoctest", "grpc_interceptor", *args)
 
 
 @nox.session(python="3.8")

--- a/poetry.lock
+++ b/poetry.lock
@@ -821,7 +821,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 testing = ["protobuf"]
 
 [metadata]
-content-hash = "2df64268d4c5c8746d9415464c9b6b1f79cbab0a0f633e9a54fb314fe23db1e9"
+content-hash = "7994ed64d6f333dcb1efa855911ba8fcea15420b4e97d1cd49ac1e896c50d67c"
 python-versions = "^3.6"
 
 [metadata.files]

--- a/poetry.lock
+++ b/poetry.lock
@@ -790,6 +790,22 @@ version = "0.2.5"
 
 [[package]]
 category = "dev"
+description = "A rewrite of the builtin doctest module"
+name = "xdoctest"
+optional = false
+python-versions = "*"
+version = "0.13.0"
+
+[package.dependencies]
+six = "*"
+
+[package.extras]
+all = ["six", "pytest", "pytest-cov", "codecov", "scikit-build", "cmake", "ninja", "pybind11", "pygments", "colorama"]
+optional = ["pygments", "colorama"]
+tests = ["pytest", "pytest-cov", "codecov", "scikit-build", "cmake", "ninja", "pybind11"]
+
+[[package]]
+category = "dev"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 marker = "python_version < \"3.8\""
 name = "zipp"
@@ -805,7 +821,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 testing = ["protobuf"]
 
 [metadata]
-content-hash = "650e8d99d38442917da86ce4b7fedb55f4b00fc9932ba0c12de8bf6d57ba9e41"
+content-hash = "2df64268d4c5c8746d9415464c9b6b1f79cbab0a0f633e9a54fb314fe23db1e9"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -1268,6 +1284,10 @@ urllib3 = [
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
     {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
+]
+xdoctest = [
+    {file = "xdoctest-0.13.0-py2.py3-none-any.whl", hash = "sha256:de861fd5230a46bd26c054b4981169dd963f813768cb62b62e104e4d2644ac94"},
+    {file = "xdoctest-0.13.0.tar.gz", hash = "sha256:4f113a430076561a9d7f31af65b5d5acda62ee06b05cb6894264cb9efb8196ac"},
 ]
 zipp = [
     {file = "zipp-3.1.0-py3-none-any.whl", hash = "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ documentation = "https://grpc-interceptor.readthedocs.io"
 [tool.poetry.dependencies]
 python = "^3.6"
 grpcio = "^1.8.0"
-protobuf = {version = "^3.6.0", optional = true}
+protobuf = {version = ">=3.6.0", optional = true}
 
 [tool.poetry.extras]
 testing = ["protobuf"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "grpc-interceptor"
-version = "0.9.0"
+version = "0.10.0"
 description = "Simplifies gRPC interceptors"
 license = "MIT"
 readme = "README.md"
@@ -36,6 +36,7 @@ mypy-protobuf = "^1.23"
 flake8-docstrings = "^1.5.0"
 sphinx = "^3.1.2"
 codecov = "^2.1.8"
+xdoctest = "^0.13.0"
 
 [tool.coverage.paths]
 source = ["src"]

--- a/src/grpc_interceptor/base.py
+++ b/src/grpc_interceptor/base.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, NamedTuple
 import grpc
 
 
-class Interceptor(grpc.ServerInterceptor, metaclass=abc.ABCMeta):
+class ServiceInterceptor(grpc.ServerInterceptor, metaclass=abc.ABCMeta):
     """Base class for server-side interceptors.
 
     To implement an interceptor, subclass this class and override the intercept method.
@@ -43,13 +43,13 @@ class Interceptor(grpc.ServerInterceptor, metaclass=abc.ABCMeta):
     def intercept_service(self, continuation, handler_call_details):
         """Implementation of grpc.ServerInterceptor.
 
-        This is not part of the Interceptor API, but must have a public name. Do not
-        override it, unless you know what you're doing.
+        This is not part of the ServiceInterceptor API, but must have a public name.
+        Do not override it, unless you know what you're doing.
         """
         next_handler = continuation(handler_call_details)
         # Make sure it's unary_unary:
         if next_handler.request_streaming or next_handler.response_streaming:
-            raise ValueError("Interceptor only handles unary_unary")
+            raise ValueError("ServiceInterceptor only handles unary_unary")
 
         def invoke_intercept_method(request, context):
             next_interceptor_or_implementation = next_handler.unary_unary
@@ -90,7 +90,7 @@ class MethodName(NamedTuple):
 
         Example:
             >>> MethodName("foo.bar", "SearchService", "Search").fully_qualified_service
-            "foo.bar.SearchService"
+            'foo.bar.SearchService'
         """
         return f"{self.package}.{self.service}" if self.package else self.service
 
@@ -100,14 +100,14 @@ def parse_method_name(method_name: str) -> MethodName:
 
     Arguments:
         method_name: A string of the form "/foo.bar.SearchService/Search", as passed to
-            Interceptor.intercept().
+            ServiceInterceptor.intercept().
 
     Returns:
         A MethodName object.
 
     Example:
         >>> parse_method_name("/foo.bar.SearchService/Search")
-        MethodName(package="foo.bar", service="SearchService", method="Search")
+        MethodName(package='foo.bar', service='SearchService', method='Search')
     """
     _, package_and_service, method = method_name.split("/")
     *maybe_package, service = package_and_service.rsplit(".", maxsplit=1)

--- a/src/grpc_interceptor/exception_to_status.py
+++ b/src/grpc_interceptor/exception_to_status.py
@@ -1,19 +1,35 @@
 """ExceptionToStatusInterceptor catches GrpcException and sets the gRPC context."""
 
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 import grpc
 
-from grpc_interceptor.base import Interceptor
+from grpc_interceptor.base import ServiceInterceptor
 from grpc_interceptor.exceptions import GrpcException
 
 
-class ExceptionToStatusInterceptor(Interceptor):
+class ExceptionToStatusInterceptor(ServiceInterceptor):
     """An interceptor that catches exceptions and sets the RPC status and details.
 
     ExceptionToStatusInterceptor will catch any subclass of GrpcException and set the
     status code and details on the gRPC context.
+
+    Args:
+        status_on_unknown_exception: Specify what to do if an exception which is
+            not a subclass of GrpcException is raised. If None, do nothing (by
+            default, grpc will set the status to UNKNOWN). If not None, then the
+            status code will be set to this value. It must not be OK. The details
+            will be set to the value of repr(e), where e is the exception. In any
+            case, the exception will be propagated.
+
+    Raises:
+        ValueError: If status_code is OK.
     """
+
+    def __init__(self, status_on_unknown_exception: Optional[grpc.StatusCode] = None):
+        if status_on_unknown_exception == grpc.StatusCode.OK:
+            raise ValueError("The status code for unknown exceptions cannot be OK")
+        self._status_on_unknown_exception = status_on_unknown_exception
 
     def intercept(
         self,
@@ -28,4 +44,9 @@ class ExceptionToStatusInterceptor(Interceptor):
         except GrpcException as e:
             context.set_code(e.status_code)
             context.set_details(e.details)
+            raise
+        except Exception as e:
+            if self._status_on_unknown_exception is not None:
+                context.set_code(self._status_on_unknown_exception)
+                context.set_details(repr(e))
             raise

--- a/src/grpc_interceptor/exceptions.py
+++ b/src/grpc_interceptor/exceptions.py
@@ -22,6 +22,12 @@ class GrpcException(Exception):
             subclasses of GrpcException. Must not be OK, because gRPC will not
             raise an RpcError to the client if the status code is OK.
         details: A string with additional informantion about the error.
+    Args:
+        details: If not None, specifies a custom error message.
+        status_code: If not None, sets the status code.
+
+    Raises:
+        ValueError: If status_code is OK.
     """
 
     status_code: StatusCode = StatusCode.UNKNOWN
@@ -30,15 +36,6 @@ class GrpcException(Exception):
     def __init__(
         self, details: Optional[str] = None, status_code: Optional[StatusCode] = None
     ):
-        """Optionally override the status code and details.
-
-        Args:
-            details: If not None, specifies a custom error message.
-            status_code: If not None, sets the status code.
-
-        Raises:
-            ValueError: If status_code is OK.
-        """
         if status_code is not None:
             if status_code == StatusCode.OK:
                 raise ValueError("The status code for an exception cannot be OK")
@@ -64,8 +61,8 @@ class GrpcException(Exception):
             The status code as a string.
 
         Example:
-            GrpcException(status_code=StatusCode.NOT_FOUND).status_string
-            >>> "NOT_FOUND"
+            >>> GrpcException(status_code=StatusCode.NOT_FOUND).status_string
+            'NOT_FOUND'
         """
         return self.status_code.name
 

--- a/src/grpc_interceptor/testing/__init__.py
+++ b/src/grpc_interceptor/testing/__init__.py
@@ -2,11 +2,11 @@
 
 from typing import Callable
 
-from grpc_interceptor.testing.dummy_client import dummy_client
+from grpc_interceptor.testing.dummy_client import dummy_client, DummyService
 from grpc_interceptor.testing.protos.dummy_pb2 import DummyRequest, DummyResponse
 
 
-__all__ = ["dummy_client", "DummyRequest", "DummyResponse", "raises"]
+__all__ = ["dummy_client", "DummyRequest", "DummyResponse", "DummyService", "raises"]
 
 
 def raises(e: Exception) -> Callable:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,19 +1,18 @@
-"""Test cases for the grpc-interceptor base Interceptor."""
+"""Test cases for the grpc-interceptor base ServiceInterceptor."""
 
 from collections import defaultdict
 
 import grpc
 import pytest
 
-from grpc_interceptor.base import Interceptor, MethodName, parse_method_name
+from grpc_interceptor.base import MethodName, parse_method_name, ServiceInterceptor
 from grpc_interceptor.testing import dummy_client, DummyRequest
 
 
-class CountingInterceptor(Interceptor):
+class CountingInterceptor(ServiceInterceptor):
     """A test interceptor that counts calls and exceptions."""
 
     def __init__(self):
-        """Initialize counts to zero."""
         self.num_calls = defaultdict(int)
         self.num_errors = defaultdict(int)
 
@@ -27,11 +26,10 @@ class CountingInterceptor(Interceptor):
             raise
 
 
-class SideEffectInterceptor(Interceptor):
+class SideEffectInterceptor(ServiceInterceptor):
     """A test interceptor that calls a function for the side effect."""
 
     def __init__(self, side_effect):
-        """Set the side effect function."""
         self._side_effect = side_effect
 
     def intercept(self, method, request, context, method_name):
@@ -40,7 +38,7 @@ class SideEffectInterceptor(Interceptor):
         return method(request, context)
 
 
-class UppercasingInterceptor(Interceptor):
+class UppercasingInterceptor(ServiceInterceptor):
     """A test interceptor that modifies the request by uppercasing the input field."""
 
     def intercept(self, method, request, context, method_name):
@@ -49,11 +47,10 @@ class UppercasingInterceptor(Interceptor):
         return method(request, context)
 
 
-class AbortingInterceptor(Interceptor):
+class AbortingInterceptor(ServiceInterceptor):
     """A test interceptor that aborts before calling the handler."""
 
     def __init__(self, message):
-        """Set the abort details."""
         self._message = message
 
     def intercept(self, method, request, context, method_name):

--- a/tests/test_exception_to_status.py
+++ b/tests/test_exception_to_status.py
@@ -1,5 +1,7 @@
 """Test cases for ExceptionToStatusInterceptor."""
 
+import re
+
 import grpc
 import pytest
 
@@ -79,7 +81,7 @@ def test_non_grpc_exception_with_override():
         with pytest.raises(grpc.RpcError) as e:
             client.Execute(DummyRequest(input="error"))
         assert e.value.code() == grpc.StatusCode.INTERNAL
-        assert e.value.details() == "ValueError('oops')"
+        assert re.fullmatch(r"ValueError\('oops',?\)", e.value.details())
 
 
 def test_override_with_ok():


### PR DESCRIPTION
Changes
* Rename Interceptor to ServiceInterceptor
* Add `status_on_unknown_exception` to `ExceptionToStatusInterceptor`
* Add `py.typed`
* Allow `protobuf` version `4.0.x` which is coming out soon and is backwards compatible
* Include `testing` in autodocs
* Turn on `xdoctest`
* Prevent autodoc from outputting default `namedtuple` docs