### PR TITLE
Add support for client interceptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based roughly on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.13.0] - 2020-12-27
+### Added
+- Client-side interceptors (thanks @villainy!)
+
+### Changed (breaking)
+- Added a `context` parameter to special case functions in the `testing` module
+
+### Fixed
+- Build issue caused by [pip upgrade](https://github.com/cjolowicz/hypermodern-python/issues/174#issuecomment-745364836)
+- Docs not building correctly in nox
+
+## [0.12.0] - 2020-10-07
+### Added
+- Support for all streaming RPCs
+
+## [0.11.0] - 2020-07-24
+### Added
+- Expose some imports from the top-level
+
+### Changed (breaking)
+- Rename to `ServerInterceptor` (do not intend to make breaking name changes after this)
+
+## [0.10.0] - 2020-07-23
+### Added
+- `status_on_unknown_exception` to `ExceptionToStatusInterceptor`
+- `py.typed` (so `mypy` will type check the package)
+
+### Fixed
+- Allow protobuf version 4.0.x which is coming out soon and is backwards compatible
+- Testing in autodocs
+- Turn on xdoctest
+- Prevent autodoc from outputting default namedtuple docs
+
+### Changed (breaking)
+- Rename `Interceptor` to `ServiceInterceptor`
+
+## [0.9.0] - 2020-07-22
+### Added
+- The `testing` module
+- Some helper functions
+- Improved test coverage
+
+### Fixed
+- Protobuf compatibility improvements
+
+## [0.8.0] - 2020-07-19
+### Added
+- An `Interceptor` base class, to make it easy to define your own service interceptors
+- An `ExceptionToStatusInterceptor` interceptor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.13.0] - 2020-12-27
 ### Added
-- Client-side interceptors (thanks @villainy!)
+- Client-side interceptors (thanks Michael Morgan!)
 
 ### Changed (breaking)
 - Added a `context` parameter to special case functions in the `testing` module

--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ class MetadataClientInterceptor(ClientInterceptor):
             method: A function that proceeds with the invocation by executing the next
                 interceptor in the chain or invoking the actual RPC on the underlying
                 channel.
-            call_details: Describes an RPC to be invoked.
             request_or_iterator: RPC request message or iterator of request messages
                 for streaming requests.
+            call_details: Describes an RPC to be invoked.
 
         Returns:
             The type of the return should match the type of the return value received
@@ -152,7 +152,7 @@ class MetadataClientInterceptor(ClientInterceptor):
             call_details.compression,
         )
 
-        return method(new_details, request_or_iterator)
+        return method(request_or_iterator, new_details)
 ```
 
 Now inject your interceptor when you create the ``grpc`` channel:

--- a/README.md
+++ b/README.md
@@ -113,11 +113,10 @@ class MetadataClientInterceptor(ClientInterceptor):
 
     def intercept(
         self,
-        call_details: ClientCallDetails,
-        request_iterator: Iterator[Message],
-        request_streaming: bool,
-        response_streaming: bool,
-    ) -> Tuple[ClientCallDetails, Iterator[Message], Optional[Callable]]:
+        method: Callable,
+        request_or_iterator: Any,
+        call_details: grpc.ClientCallDetails,
+    ):
         """Override this method to implement a custom interceptor.
 
         This method is called for all unary and streaming RPCs. The interceptor
@@ -156,10 +155,6 @@ class MetadataClientInterceptor(ClientInterceptor):
         return method(new_details, request_or_iterator)
 ```
 
-An optional callback function can be included as the third element of the
-`intercept` function's return tuple. This can be used for additional
-post-processing of the intercepted call.
-
 Now inject your interceptor when you create the ``grpc`` channel:
 
 ```python
@@ -168,6 +163,10 @@ with grpc.insecure_channel("grpc-server:50051") as channel:
     channel = grpc.intercept_channel(channel, *interceptors)
     ...
 ```
+
+Client interceptors can also be used to retry RPCs that fail due to specific errors, or
+a host of other use cases. There are some basic approaches in the tests to get you
+started.
 
 # Documentation
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -163,9 +163,9 @@ a client interceptor:
                 method: A function that proceeds with the invocation by executing the next
                     interceptor in the chain or invoking the actual RPC on the underlying
                     channel.
-                call_details: Describes an RPC to be invoked.
                 request_or_iterator: RPC request message or iterator of request messages
                     for streaming requests.
+                call_details: Describes an RPC to be invoked.
 
             Returns:
                 The type of the return should match the type of the return value received
@@ -185,7 +185,7 @@ a client interceptor:
                 call_details.compression,
             )
 
-            return method(new_details, request_or_iterator)
+            return method(request_or_iterator, new_details)
 
 Now inject your interceptor when you create the ``grpc`` channel:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -135,8 +135,8 @@ and having it be handled automatically.
 Client Interceptors
 ^^^^^^^^^^^^^^^^^^^
 
-To define your own client interceptor, we will use a simple invocation metadata injecting 
-interceptor as an example:
+We will use an invocation metadata injecting interceptor as an example of defining
+a client interceptor:
 
 .. code-block:: python
 
@@ -155,21 +155,26 @@ interceptor as an example:
             This method is called for all unary and streaming RPCs. The interceptor
             implementation should call `method` using a `grpc.ClientCallDetails` and the
             `request_or_iterator` object as parameters. The `request_or_iterator`
-            parameter should be type checked to determine if this is a singluar request
+            parameter may be type checked to determine if this is a singluar request
             for unary RPCs or an iterator for client-streaming or client-server streaming
             RPCs.
 
             Args:
-                method (Callable): A function that proceeds with the invocation by
-                executing the next interceptor in chain or invoking the actual RPC on the
-                underlying Channel.
-                call_details (grpc.ClientCallDetails): Describes an RPC to be invoked
-                request_or_iterator (Any): RPC request message(s)
+                method: A function that proceeds with the invocation by executing the next
+                    interceptor in the chain or invoking the actual RPC on the underlying
+                    channel.
+                call_details: Describes an RPC to be invoked.
+                request_or_iterator: RPC request message or iterator of request messages
+                    for streaming requests.
 
             Returns:
-                The return for an interceptor should match the return interface for a
-                continuation. This is an object that is both a Call for the RPC and a
-                Future.
+                The type of the return should match the type of the return value received
+                by calling `method`. This is an object that is both a
+                `Call <https://grpc.github.io/grpc/python/grpc.html#grpc.Call>`_ for the
+                RPC and a `Future <https://grpc.github.io/grpc/python/grpc.html#grpc.Future>`_.
+
+                The actual result from the RPC can be got by calling `.result()` on the
+                value returned from `method`.
             """
             new_details = ClientCallDetails(
                 call_details.method,
@@ -190,6 +195,10 @@ Now inject your interceptor when you create the ``grpc`` channel:
     with grpc.insecure_channel("grpc-server:50051") as channel:
         channel = grpc.intercept_channel(channel, *interceptors)
         ...
+
+Client interceptors can also be used to retry RPCs that fail due to specific errors, or
+a host of other use cases. There are some basic approaches in the tests to get you
+started.
 
 Testing
 -------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -149,7 +149,7 @@ a client interceptor:
             method: Callable,
             request_or_iterator: Any,
             call_details: grpc.ClientCallDetails,
-        ) -> Any:
+        ):
             """Override this method to implement a custom interceptor.
 
             This method is called for all unary and streaming RPCs. The interceptor

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,8 @@ The ``grpc_interceptor`` package provides the following:
   that set the gRPC status code correctly (rather than the default of every exception
   resulting in an ``UNKNOWN`` status code). This is something for which pretty much any
   service will have a use.
+* A ``ClientInterceptor`` base class, to make it easy to define your own client-side interceptors.
+  Do not confuse this with the ``grpc.ClientInterceptor`` class.
 * An optional testing framework. If you're writing your own interceptors, this is useful.
   If you're just using ``ExceptionToStatusInterceptor`` then you don't need this.
 
@@ -52,7 +54,10 @@ To also install the testing framework:
 Usage
 -----
 
-To define your own interceptor (we can use a simplified version of
+Server Interceptors
+^^^^^^^^^^^^^^^^^^^
+
+To define your own server interceptor (we can use a simplified version of
 ``ExceptionToStatusInterceptor`` as an example):
 
 .. code-block:: python
@@ -127,6 +132,63 @@ helper functions so they can call ``context.abort`` or ``context.set_code``. It 
 the more Pythonic approach of just raising an exception from anywhere in the code,
 and having it be handled automatically.
 
+Client Interceptors
+^^^^^^^^^^^^^^^^^^^
+
+To define your own client interceptor, we will use a simple invocation metadata injecting 
+interceptor as an example:
+
+.. code-block:: python
+
+    from grpc_interceptor import ClientCallDetails, ClientInterceptor
+
+    class MetadataClientInterceptor(ClientInterceptor):
+
+        def intercept(
+            self,
+            call_details: ClientCallDetails,
+            request_iterator: Iterator[Message],
+            request_streaming: bool,
+            response_streaming: bool,
+        ) -> Tuple[ClientCallDetails, Iterator[Message], Optional[Callable]]:
+            """Override this method to implement a custom interceptor.
+
+            This method is called for all unary and streaming RPCs with the
+            appropriate boolean parameters set. The returned
+            ClientCallDetails and request message(s) will be passed to
+            either the next interceptor or RPC implementation. An optional
+            callback function can be returned to perform postprocessing on RPC
+            responses.
+
+            Args:
+                call_details (ClientCallDetails): Describes an RPC to be invoked
+                request_iterator (Iterator[Message]): RPC request messages
+                request_streaming (bool): True if RPC is client or bi-directional streaming
+                response_streaming (bool): True if PRC is server or bi-directional streaming
+
+            Returns:
+                This should return a tuple of ClientCallDetails, RPC request
+                message iterator, and a postprocessing callback function or None.
+            """
+            call_details.metadata.append(
+                ("authorization", "Bearer mysecrettoken")
+            )
+
+            return call_details, request_iterator, None
+
+An optional callback function can be included as the third element of the ``intercept``
+function's return tuple. This can be used for additional post-processing of the intercepted
+call.
+
+Now inject your interceptor when you create the ``grpc`` channel:
+
+.. code-block:: python
+
+    interceptors = [MetadataClientInterceptor()]
+    with grpc.insecure_channel("grpc-server:50051") as channel:
+        channel = grpc.intercept_channel(channel, *interceptors)
+        ...
+
 Testing
 -------
 
@@ -137,10 +199,15 @@ framework, and also allows chaining interceptors.
 
 The crux of the testing framework is the ``dummy_client`` context manager. It provides
 a client to a gRPC service, which by defaults echos the ``input`` field of the request
-to the ``output`` field of the response. You can also provide a ``special_cases`` dict
-which tells the service to call arbitrary functions when the input matches a key in the
-dict. This allows you to test things like exceptions being thrown. Here's an example
-(again using ``ExceptionToStatusInterceptor``):
+to the ``output`` field of the response.
+
+You can also provide a ``special_cases`` dict which tells the service to call arbitrary
+functions when the input matches a key in the dict. This allows you to test things like
+exceptions being thrown. Similarly you can provide a ``context_cases`` dict to call
+functions against the ``grpc.ServicerContext``. This can be used, for example, to include
+invocation metadata in the result text for validation.
+
+Here's an example (again using ``ExceptionToStatusInterceptor``):
 
 .. code-block:: python
 
@@ -162,7 +229,4 @@ dict. This allows you to test things like exceptions being thrown. Here's an exa
 Limitations
 -----------
 
-These are the current limitations, although supporting these is possible. Contributions
-or requests are welcome.
-
-* The package only provides service interceptors.
+Contributions or requests are welcome for any limitations you may find.

--- a/noxfile.py
+++ b/noxfile.py
@@ -107,6 +107,7 @@ def install_with_constraints(session, *args, **kwargs):
             "--dev",
             "--format=requirements.txt",
             f"--output={requirements}",
+            "--without-hashes",
             external=True,
         )
         session.install(f"--constraint={requirements}", *args, **kwargs)

--- a/noxfile.py
+++ b/noxfile.py
@@ -42,7 +42,7 @@ def coverage(session):
 @nox.session(python="3.8")
 def docs(session):
     """Build the documentation."""
-    session.run("poetry", "install", "--no-dev", external=True)
+    session.run("poetry", "install", "--no-dev", "-E", "testing", external=True)
     install_with_constraints(session, "sphinx")
     session.run("sphinx-build", "docs", "docs/_build")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "grpc-interceptor"
-version = "0.12.0"
+version = "0.13.0"
 description = "Simplifies gRPC interceptors"
 license = "MIT"
 readme = "README.md"

--- a/src/grpc_interceptor/__init__.py
+++ b/src/grpc_interceptor/__init__.py
@@ -1,10 +1,13 @@
 """Simplified Python gRPC interceptors."""
 
+from grpc_interceptor.client import ClientCallDetails, ClientInterceptor
 from grpc_interceptor.exception_to_status import ExceptionToStatusInterceptor
 from grpc_interceptor.server import MethodName, parse_method_name, ServerInterceptor
 
 
 __all__ = [
+    "ClientCallDetails",
+    "ClientInterceptor",
     "ExceptionToStatusInterceptor",
     "MethodName",
     "parse_method_name",

--- a/src/grpc_interceptor/__init__.py
+++ b/src/grpc_interceptor/__init__.py
@@ -1,11 +1,12 @@
 """Simplified Python gRPC interceptors."""
 
-from grpc_interceptor.client import ClientInterceptor
+from grpc_interceptor.client import ClientCallDetails, ClientInterceptor
 from grpc_interceptor.exception_to_status import ExceptionToStatusInterceptor
 from grpc_interceptor.server import MethodName, parse_method_name, ServerInterceptor
 
 
 __all__ = [
+    "ClientCallDetails",
     "ClientInterceptor",
     "ExceptionToStatusInterceptor",
     "MethodName",

--- a/src/grpc_interceptor/__init__.py
+++ b/src/grpc_interceptor/__init__.py
@@ -1,12 +1,11 @@
 """Simplified Python gRPC interceptors."""
 
-from grpc_interceptor.client import ClientCallDetails, ClientInterceptor
+from grpc_interceptor.client import ClientInterceptor
 from grpc_interceptor.exception_to_status import ExceptionToStatusInterceptor
 from grpc_interceptor.server import MethodName, parse_method_name, ServerInterceptor
 
 
 __all__ = [
-    "ClientCallDetails",
     "ClientInterceptor",
     "ExceptionToStatusInterceptor",
     "MethodName",

--- a/src/grpc_interceptor/client.py
+++ b/src/grpc_interceptor/client.py
@@ -1,9 +1,43 @@
 """Base class for client-side interceptors."""
 
 import abc
-from typing import Any, Callable, Iterator, Optional, Tuple
+from collections import namedtuple
+from typing import Any, Callable, Iterator
 
 import grpc
+
+
+class ClientCallDetails(
+    namedtuple(
+        "ClientCallDetails",
+        (
+            "method",
+            "timeout",
+            "metadata",
+            "credentials",
+            "wait_for_ready",
+            "compression",
+        ),
+    ),
+    grpc.ClientCallDetails,
+):
+    """Describes an RPC to be invoked.
+
+    This is an EXPERIMENTAL API.
+
+    Attributes:
+        method: The method name of the RPC.
+        timeout: An optional duration of time in seconds to allow for the RPC.
+        metadata: Optional :term:`metadata` to be transmitted to the
+                  service-side of the RPC.
+        credentials: An optional CallCredentials for the RPC.
+        wait_for_ready: This is an EXPERIMENTAL argument. An optional flag to
+                        enable :term:`wait_for_ready` mechanism.
+        compression: An element of grpc.compression, e.g. grpc.compression.Gzip.
+                     This is an EXPERIMENTAL option.
+    """
+
+    pass
 
 
 class ClientInterceptor(
@@ -24,7 +58,7 @@ class ClientInterceptor(
         method: Callable,
         request_or_iterator: Any,
         call_details: grpc.ClientCallDetails,
-    ) -> Tuple[grpc.ClientCallDetails, Iterator[Any], Optional[Callable]]:
+    ) -> Any:
         """Override this method to implement a custom interceptor.
 
         This method is called for all unary and streaming RPCs. The interceptor

--- a/src/grpc_interceptor/client.py
+++ b/src/grpc_interceptor/client.py
@@ -1,43 +1,9 @@
 """Base class for client-side interceptors."""
 
 import abc
-from collections import namedtuple
 from typing import Any, Callable, Iterator, Optional, Tuple
 
 import grpc
-
-
-class ClientCallDetails(
-    namedtuple(
-        "ClientCallDetails",
-        (
-            "method",
-            "timeout",
-            "metadata",
-            "credentials",
-            "wait_for_ready",
-            "compression",
-        ),
-    ),
-    grpc.ClientCallDetails,
-):
-    """Describes an RPC to be invoked.
-
-    This is an EXPERIMENTAL API.
-
-    Attributes:
-        method: The method name of the RPC.
-        timeout: An optional duration of time in seconds to allow for the RPC.
-        metadata: Optional :term:`metadata` to be transmitted to the
-                  service-side of the RPC.
-        credentials: An optional CallCredentials for the RPC.
-        wait_for_ready: This is an EXPERIMENTAL argument. An optional flag to
-                        enable :term:`wait_for_ready` mechanism.
-        compression: An element of grpc.compression, e.g. grpc.compression.Gzip.
-                     This is an EXPERIMENTAL option.
-    """
-
-    pass
 
 
 class ClientInterceptor(
@@ -55,34 +21,37 @@ class ClientInterceptor(
     @abc.abstractmethod
     def intercept(
         self,
-        call_details: ClientCallDetails,
+        call_details: grpc.ClientCallDetails,
         request_iterator: Iterator[Any],
         request_streaming: bool,
         response_streaming: bool,
-    ) -> Tuple[ClientCallDetails, Iterator[Any], Optional[Callable]]:
+    ) -> Tuple[grpc.ClientCallDetails, Iterator[Any], Optional[Callable]]:
         """Override this method to implement a custom interceptor.
 
         This method is called for all unary and streaming RPCs with the
         appropriate boolean parameters set. The returned
-        ClientCallDetails and request message(s) will be passed to
+        grpc.ClientCallDetails and request message(s) will be passed to
         either the next interceptor or RPC implementation. An optional
         callback function can be returned to perform postprocessing on RPC
         responses.
 
         Args:
-            call_details (ClientCallDetails): Describes an RPC to be invoked
+            call_details (grpc.ClientCallDetails): Describes an RPC to be invoked
             request_iterator (Iterator[Any]): RPC request messages
             request_streaming (bool): True if RPC is client or bi-directional streaming
             response_streaming (bool): True if PRC is server or bi-directional streaming
 
         Returns:
-            This should return a tuple of ClientCallDetails, RPC request
+            This should return a tuple of grpc.ClientCallDetails, RPC request
             message iterator, and a postprocessing callback function or None.
         """
         return call_details, request_iterator, None  # pragma: no cover
 
     def intercept_unary_unary(
-        self, continuation: Callable, call_details: ClientCallDetails, request: Any,
+        self,
+        continuation: Callable,
+        call_details: grpc.ClientCallDetails,
+        request: Any,
     ):
         """Implementation of grpc.UnaryUnaryClientInterceptor.
 
@@ -103,7 +72,10 @@ class ClientInterceptor(
         return response
 
     def intercept_unary_stream(
-        self, continuation: Callable, call_details: ClientCallDetails, request: Any,
+        self,
+        continuation: Callable,
+        call_details: grpc.ClientCallDetails,
+        request: Any,
     ):
         """Implementation of grpc.UnaryStreamClientInterceptor.
 
@@ -126,7 +98,7 @@ class ClientInterceptor(
     def intercept_stream_unary(
         self,
         continuation: Callable,
-        call_details: ClientCallDetails,
+        call_details: grpc.ClientCallDetails,
         request_iterator: Iterator[Any],
     ):
         """Implementation of grpc.StreamUnaryClientInterceptor.
@@ -150,7 +122,7 @@ class ClientInterceptor(
     def intercept_stream_stream(
         self,
         continuation: Callable,
-        call_details: ClientCallDetails,
+        call_details: grpc.ClientCallDetails,
         request_iterator: Iterator[Any],
     ):
         """Implementation of grpc.StreamStreamClientInterceptor.

--- a/src/grpc_interceptor/client.py
+++ b/src/grpc_interceptor/client.py
@@ -130,7 +130,7 @@ class ClientInterceptor(
         """
         new_details, new_request_iterator, postprocess = self.intercept(
             call_details=call_details,
-            request_iterator=iter((request_iterator,)),
+            request_iterator=request_iterator,
             request_streaming=True,
             response_streaming=False,
         )
@@ -154,7 +154,7 @@ class ClientInterceptor(
         """
         new_details, new_request_iterator, postprocess = self.intercept(
             call_details=call_details,
-            request_iterator=iter((request_iterator,)),
+            request_iterator=request_iterator,
             request_streaming=True,
             response_streaming=True,
         )

--- a/src/grpc_interceptor/client.py
+++ b/src/grpc_interceptor/client.py
@@ -1,0 +1,166 @@
+"""Base class for client-side interceptors."""
+
+import abc
+from dataclasses import dataclass, field
+from typing import Callable, Iterator, List, Optional, Tuple
+
+from google.protobuf.message import Message
+import grpc
+
+
+@dataclass
+class ClientCallDetails(grpc.ClientCallDetails):
+    """Describes an RPC to be invoked.
+
+    This is an EXPERIMENTAL API.
+
+    Attributes:
+    method: The method name of the RPC.
+    timeout: An optional duration of time in seconds to allow for the RPC.
+    metadata: Optional :term:`metadata` to be transmitted to
+        the service-side of the RPC.
+    credentials: An optional CallCredentials for the RPC.
+    wait_for_ready: This is an EXPERIMENTAL argument. An optional
+            flag to enable :term:`wait_for_ready` mechanism.
+    compression: An element of grpc.compression, e.g.
+        grpc.compression.Gzip. This is an EXPERIMENTAL option.
+    """
+
+    method: str
+    timeout: Optional[int] = field(default=None)
+    metadata: List[Tuple[str, str]] = field(default_factory=list)
+    credentials: Optional[grpc.CallCredentials] = field(default=None)
+    wait_for_ready: Optional[bool] = field(default=None)
+    compression: Optional[grpc.Compression] = field(default=None)
+
+
+class ClientInterceptor(
+    grpc.UnaryUnaryClientInterceptor,
+    grpc.UnaryStreamClientInterceptor,
+    grpc.StreamUnaryClientInterceptor,
+    grpc.StreamStreamClientInterceptor,
+    metaclass=abc.ABCMeta,
+):
+    """Base class for client-side interceptors.
+
+    To implement an interceptor, subclass this class and override the intercept method.
+    """
+
+    @abc.abstractmethod
+    def intercept(
+        self,
+        call_details: ClientCallDetails,
+        request_iterator: Iterator[Message],
+        request_streaming: bool,
+        response_streaming: bool,
+    ) -> Tuple[ClientCallDetails, Iterator[Message], Optional[Callable]]:
+        """Override this method to implement a custom interceptor.
+
+        This method is called for all unary and streaming RPCs with the
+        appropriate boolean parameters set. The returned
+        ClientCallDetails and request message(s) will be passed to
+        either the next interceptor or RPC implementation. An optional
+        callback function can be returned to perform postprocessing on RPC
+        responses.
+
+        Args:
+            call_details (ClientCallDetails): Describes an RPC to be invoked
+            request_iterator (Iterator[Message]): RPC request messages
+            request_streaming (bool): True if RPC is client or bi-directional streaming
+            response_streaming (bool): True if PRC is server or bi-directional streaming
+
+        Returns:
+            This should return a tuple of ClientCallDetails, RPC request
+            message iterator, and a postprocessing callback function or None.
+        """
+        return call_details, request_iterator, None  # pragma: no cover
+
+    def intercept_unary_unary(
+        self, continuation: Callable, call_details: ClientCallDetails, request: Message,
+    ):
+        """Implementation of grpc.UnaryUnaryClientInterceptor.
+
+        This is not part of the grpc_interceptor.ClientInterceptor API, but must have
+        a public name. Do not override it, unless you know what you're doing.
+        """
+        new_details, new_request_iterator, postprocess = self.intercept(
+            call_details=call_details,
+            request_iterator=iter((request,)),
+            request_streaming=False,
+            response_streaming=False,
+        )
+        response = continuation(new_details, next(new_request_iterator))
+
+        if postprocess:
+            return postprocess(response)
+
+        return response
+
+    def intercept_unary_stream(
+        self, continuation: Callable, call_details: ClientCallDetails, request: Message,
+    ):
+        """Implementation of grpc.UnaryStreamClientInterceptor.
+
+        This is not part of the grpc_interceptor.ClientInterceptor API, but must have
+        a public name. Do not override it, unless you know what you're doing.
+        """
+        new_details, new_request_iterator, postprocess = self.intercept(
+            call_details=call_details,
+            request_iterator=iter((request,)),
+            request_streaming=False,
+            response_streaming=True,
+        )
+        response_iterator = continuation(new_details, next(new_request_iterator))
+
+        if postprocess:
+            return postprocess(response_iterator)
+
+        return response_iterator
+
+    def intercept_stream_unary(
+        self,
+        continuation: Callable,
+        call_details: ClientCallDetails,
+        request_iterator: Iterator[Message],
+    ):
+        """Implementation of grpc.StreamUnaryClientInterceptor.
+
+        This is not part of the grpc_interceptor.ClientInterceptor API, but must have
+        a public name. Do not override it, unless you know what you're doing.
+        """
+        new_details, new_request_iterator, postprocess = self.intercept(
+            call_details=call_details,
+            request_iterator=iter((request_iterator,)),
+            request_streaming=True,
+            response_streaming=False,
+        )
+        response = continuation(new_details, new_request_iterator)
+
+        if postprocess:
+            return postprocess(response)
+
+        return response
+
+    def intercept_stream_stream(
+        self,
+        continuation: Callable,
+        call_details: ClientCallDetails,
+        request_iterator: Iterator[Message],
+    ):
+        """Implementation of grpc.StreamStreamClientInterceptor.
+
+        This is not part of the grpc_interceptor.ClientInterceptor API, but must have
+        a public name. Do not override it, unless you know what you're doing.
+        """
+        new_details, new_request_iterator, postprocess = self.intercept(
+            call_details=call_details,
+            request_iterator=iter((request_iterator,)),
+            request_streaming=True,
+            response_streaming=True,
+        )
+        response_iterator = continuation(new_details, new_request_iterator)
+
+        if postprocess:
+            return postprocess(response_iterator)
+
+        return response_iterator

--- a/src/grpc_interceptor/client.py
+++ b/src/grpc_interceptor/client.py
@@ -59,7 +59,7 @@ class ClientInterceptor(
         This is not part of the grpc_interceptor.ClientInterceptor API, but must have
         a public name. Do not override it, unless you know what you're doing.
         """
-        response = self.intercept(continuation, call_details, request)
+        response = self.intercept(continuation, request, call_details)
 
         return response
 
@@ -74,7 +74,7 @@ class ClientInterceptor(
         This is not part of the grpc_interceptor.ClientInterceptor API, but must have
         a public name. Do not override it, unless you know what you're doing.
         """
-        response = self.intercept(continuation, call_details, request)
+        response = self.intercept(continuation, request, call_details)
 
         return response
 
@@ -89,7 +89,7 @@ class ClientInterceptor(
         This is not part of the grpc_interceptor.ClientInterceptor API, but must have
         a public name. Do not override it, unless you know what you're doing.
         """
-        response = self.intercept(continuation, call_details, request_iterator)
+        response = self.intercept(continuation, request_iterator, call_details)
 
         return response
 
@@ -104,6 +104,6 @@ class ClientInterceptor(
         This is not part of the grpc_interceptor.ClientInterceptor API, but must have
         a public name. Do not override it, unless you know what you're doing.
         """
-        response = self.intercept(continuation, call_details, request_iterator)
+        response = self.intercept(continuation, request_iterator, call_details)
 
         return response

--- a/src/grpc_interceptor/client.py
+++ b/src/grpc_interceptor/client.py
@@ -24,6 +24,11 @@ class ClientCallDetails(_ClientCallDetailsFields, grpc.ClientCallDetails):
     pass
 
 
+class ClientInterceptorReturnType(grpc.Call, grpc.Future):
+    """Return type for the ClientInterceptor.intercept method."""
+    pass
+
+
 class ClientInterceptor(
     grpc.UnaryUnaryClientInterceptor,
     grpc.UnaryStreamClientInterceptor,
@@ -42,7 +47,7 @@ class ClientInterceptor(
         method: Callable,
         request_or_iterator: Any,
         call_details: grpc.ClientCallDetails,
-    ) -> Any:
+    ) -> ClientInterceptorReturnType:
         """Override this method to implement a custom interceptor.
 
         This method is called for all unary and streaming RPCs. The interceptor

--- a/src/grpc_interceptor/client.py
+++ b/src/grpc_interceptor/client.py
@@ -1,40 +1,24 @@
 """Base class for client-side interceptors."""
 
 import abc
-from collections import namedtuple
-from typing import Any, Callable, Iterator
+from typing import Any, Callable, Iterator, NamedTuple, Optional, Sequence, Tuple, Union
 
 import grpc
 
 
-class ClientCallDetails(
-    namedtuple(
-        "ClientCallDetails",
-        (
-            "method",
-            "timeout",
-            "metadata",
-            "credentials",
-            "wait_for_ready",
-            "compression",
-        ),
-    ),
-    grpc.ClientCallDetails,
-):
+class _ClientCallDetailsFields(NamedTuple):
+    method: str
+    timeout: Optional[float]
+    metadata: Optional[Sequence[Tuple[str, Union[str, bytes]]]]
+    credentials: Optional[grpc.CallCredentials]
+    wait_for_ready: Optional[bool]
+    compression: Optional[grpc.Compression]
+
+
+class ClientCallDetails(_ClientCallDetailsFields, grpc.ClientCallDetails):
     """Describes an RPC to be invoked.
 
-    This is an EXPERIMENTAL API.
-
-    Attributes:
-        method: The method name of the RPC.
-        timeout: An optional duration of time in seconds to allow for the RPC.
-        metadata: Optional :term:`metadata` to be transmitted to the
-                  service-side of the RPC.
-        credentials: An optional CallCredentials for the RPC.
-        wait_for_ready: This is an EXPERIMENTAL argument. An optional flag to
-                        enable :term:`wait_for_ready` mechanism.
-        compression: An element of grpc.compression, e.g. grpc.compression.Gzip.
-                     This is an EXPERIMENTAL option.
+    See https://grpc.github.io/grpc/python/grpc.html#grpc.ClientCallDetails
     """
 
     pass
@@ -64,21 +48,27 @@ class ClientInterceptor(
         This method is called for all unary and streaming RPCs. The interceptor
         implementation should call `method` using a `grpc.ClientCallDetails` and the
         `request_or_iterator` object as parameters. The `request_or_iterator`
-        parameter should be type checked to determine if this is a singluar request
+        parameter may be type checked to determine if this is a singluar request
         for unary RPCs or an iterator for client-streaming or client-server streaming
         RPCs.
 
         Args:
-            method (Callable): A function that proceeds with the invocation by
-            executing the next interceptor in chain or invoking the actual RPC on the
-            underlying Channel.
-            call_details (grpc.ClientCallDetails): Describes an RPC to be invoked
-            request_or_iterator (Any): RPC request message(s)
+            method: A function that proceeds with the invocation by executing the next
+                interceptor in the chain or invoking the actual RPC on the underlying
+                channel.
+            call_details: Describes an RPC to be invoked.
+            request_or_iterator: RPC request message or iterator of request messages
+                for streaming requests.
 
         Returns:
-            The return for an interceptor should match the return interface for a
-            continuation. This is an object that is both a Call for the RPC and a
-            Future.
+            The type of the return should match the type of the return value received
+            by calling `method`. This is an object that is both a
+            `Call <https://grpc.github.io/grpc/python/grpc.html#grpc.Call>`_ for the
+            RPC and a
+            `Future <https://grpc.github.io/grpc/python/grpc.html#grpc.Future>`_.
+
+            The actual result from the RPC can be got by calling `.result()` on the
+            value returned from `method`.
         """
         return method(call_details, request_or_iterator)  # pragma: no cover
 
@@ -93,9 +83,7 @@ class ClientInterceptor(
         This is not part of the grpc_interceptor.ClientInterceptor API, but must have
         a public name. Do not override it, unless you know what you're doing.
         """
-        response = self.intercept(continuation, request, call_details)
-
-        return response
+        return self.intercept(continuation, request, call_details)
 
     def intercept_unary_stream(
         self,
@@ -108,9 +96,7 @@ class ClientInterceptor(
         This is not part of the grpc_interceptor.ClientInterceptor API, but must have
         a public name. Do not override it, unless you know what you're doing.
         """
-        response = self.intercept(continuation, request, call_details)
-
-        return response
+        return self.intercept(continuation, request, call_details)
 
     def intercept_stream_unary(
         self,
@@ -123,9 +109,7 @@ class ClientInterceptor(
         This is not part of the grpc_interceptor.ClientInterceptor API, but must have
         a public name. Do not override it, unless you know what you're doing.
         """
-        response = self.intercept(continuation, request_iterator, call_details)
-
-        return response
+        return self.intercept(continuation, request_iterator, call_details)
 
     def intercept_stream_stream(
         self,
@@ -138,6 +122,4 @@ class ClientInterceptor(
         This is not part of the grpc_interceptor.ClientInterceptor API, but must have
         a public name. Do not override it, unless you know what you're doing.
         """
-        response = self.intercept(continuation, request_iterator, call_details)
-
-        return response
+        return self.intercept(continuation, request_iterator, call_details)

--- a/src/grpc_interceptor/client.py
+++ b/src/grpc_interceptor/client.py
@@ -21,31 +21,32 @@ class ClientInterceptor(
     @abc.abstractmethod
     def intercept(
         self,
+        continuation: Callable,
         call_details: grpc.ClientCallDetails,
-        request_iterator: Iterator[Any],
-        request_streaming: bool,
-        response_streaming: bool,
+        request_or_iterator: Any,
     ) -> Tuple[grpc.ClientCallDetails, Iterator[Any], Optional[Callable]]:
         """Override this method to implement a custom interceptor.
 
-        This method is called for all unary and streaming RPCs with the
-        appropriate boolean parameters set. The returned
-        grpc.ClientCallDetails and request message(s) will be passed to
-        either the next interceptor or RPC implementation. An optional
-        callback function can be returned to perform postprocessing on RPC
-        responses.
+        This method is called for all unary and streaming RPCs. The
+        `request_or_iterator` parameter should be type checked to determine if this
+        is a singluar request for unary RPCs or an iterator for client-streaming or
+        client-server streaming RPCs. The interceptor implementation should call
+        `continuation` using a `grpc.ClientCallDetails` and the `request_or_iterator`
+        object as parameters.
 
         Args:
+            continuation (Callable): A function that proceeds with the invocation by
+            executing the next interceptor in chain or invoking the actual RPC on the
+            underlying Channel.
             call_details (grpc.ClientCallDetails): Describes an RPC to be invoked
-            request_iterator (Iterator[Any]): RPC request messages
-            request_streaming (bool): True if RPC is client or bi-directional streaming
-            response_streaming (bool): True if PRC is server or bi-directional streaming
+            request_or_iterator (Any): RPC request message(s)
 
         Returns:
-            This should return a tuple of grpc.ClientCallDetails, RPC request
-            message iterator, and a postprocessing callback function or None.
+            The return for an interceptor should match the return interface for a
+            continuation. This is an object that is both a Call for the RPC and a
+            Future.
         """
-        return call_details, request_iterator, None  # pragma: no cover
+        return continuation(call_details, request_or_iterator)  # pragma: no cover
 
     def intercept_unary_unary(
         self,
@@ -58,16 +59,7 @@ class ClientInterceptor(
         This is not part of the grpc_interceptor.ClientInterceptor API, but must have
         a public name. Do not override it, unless you know what you're doing.
         """
-        new_details, new_request_iterator, postprocess = self.intercept(
-            call_details=call_details,
-            request_iterator=iter((request,)),
-            request_streaming=False,
-            response_streaming=False,
-        )
-        response = continuation(new_details, next(new_request_iterator))
-
-        if postprocess:
-            return postprocess(response)
+        response = self.intercept(continuation, call_details, request)
 
         return response
 
@@ -82,18 +74,9 @@ class ClientInterceptor(
         This is not part of the grpc_interceptor.ClientInterceptor API, but must have
         a public name. Do not override it, unless you know what you're doing.
         """
-        new_details, new_request_iterator, postprocess = self.intercept(
-            call_details=call_details,
-            request_iterator=iter((request,)),
-            request_streaming=False,
-            response_streaming=True,
-        )
-        response_iterator = continuation(new_details, next(new_request_iterator))
+        response = self.intercept(continuation, call_details, request)
 
-        if postprocess:
-            return postprocess(response_iterator)
-
-        return response_iterator
+        return response
 
     def intercept_stream_unary(
         self,
@@ -106,16 +89,7 @@ class ClientInterceptor(
         This is not part of the grpc_interceptor.ClientInterceptor API, but must have
         a public name. Do not override it, unless you know what you're doing.
         """
-        new_details, new_request_iterator, postprocess = self.intercept(
-            call_details=call_details,
-            request_iterator=request_iterator,
-            request_streaming=True,
-            response_streaming=False,
-        )
-        response = continuation(new_details, new_request_iterator)
-
-        if postprocess:
-            return postprocess(response)
+        response = self.intercept(continuation, call_details, request_iterator)
 
         return response
 
@@ -130,15 +104,6 @@ class ClientInterceptor(
         This is not part of the grpc_interceptor.ClientInterceptor API, but must have
         a public name. Do not override it, unless you know what you're doing.
         """
-        new_details, new_request_iterator, postprocess = self.intercept(
-            call_details=call_details,
-            request_iterator=request_iterator,
-            request_streaming=True,
-            response_streaming=True,
-        )
-        response_iterator = continuation(new_details, new_request_iterator)
+        response = self.intercept(continuation, call_details, request_iterator)
 
-        if postprocess:
-            return postprocess(response_iterator)
-
-        return response_iterator
+        return response

--- a/src/grpc_interceptor/client.py
+++ b/src/grpc_interceptor/client.py
@@ -21,21 +21,21 @@ class ClientInterceptor(
     @abc.abstractmethod
     def intercept(
         self,
-        continuation: Callable,
-        call_details: grpc.ClientCallDetails,
+        method: Callable,
         request_or_iterator: Any,
+        call_details: grpc.ClientCallDetails,
     ) -> Tuple[grpc.ClientCallDetails, Iterator[Any], Optional[Callable]]:
         """Override this method to implement a custom interceptor.
 
-        This method is called for all unary and streaming RPCs. The
-        `request_or_iterator` parameter should be type checked to determine if this
-        is a singluar request for unary RPCs or an iterator for client-streaming or
-        client-server streaming RPCs. The interceptor implementation should call
-        `continuation` using a `grpc.ClientCallDetails` and the `request_or_iterator`
-        object as parameters.
+        This method is called for all unary and streaming RPCs. The interceptor
+        implementation should call `method` using a `grpc.ClientCallDetails` and the
+        `request_or_iterator` object as parameters. The `request_or_iterator`
+        parameter should be type checked to determine if this is a singluar request
+        for unary RPCs or an iterator for client-streaming or client-server streaming
+        RPCs.
 
         Args:
-            continuation (Callable): A function that proceeds with the invocation by
+            method (Callable): A function that proceeds with the invocation by
             executing the next interceptor in chain or invoking the actual RPC on the
             underlying Channel.
             call_details (grpc.ClientCallDetails): Describes an RPC to be invoked
@@ -46,7 +46,7 @@ class ClientInterceptor(
             continuation. This is an object that is both a Call for the RPC and a
             Future.
         """
-        return continuation(call_details, request_or_iterator)  # pragma: no cover
+        return method(call_details, request_or_iterator)  # pragma: no cover
 
     def intercept_unary_unary(
         self,

--- a/src/grpc_interceptor/client.py
+++ b/src/grpc_interceptor/client.py
@@ -1,36 +1,43 @@
 """Base class for client-side interceptors."""
 
 import abc
-from dataclasses import dataclass, field
-from typing import Any, Callable, Iterator, List, Optional, Tuple
+from collections import namedtuple
+from typing import Any, Callable, Iterator, Optional, Tuple
 
 import grpc
 
 
-@dataclass
-class ClientCallDetails(grpc.ClientCallDetails):
+class ClientCallDetails(
+    namedtuple(
+        "ClientCallDetails",
+        (
+            "method",
+            "timeout",
+            "metadata",
+            "credentials",
+            "wait_for_ready",
+            "compression",
+        ),
+    ),
+    grpc.ClientCallDetails,
+):
     """Describes an RPC to be invoked.
 
     This is an EXPERIMENTAL API.
 
     Attributes:
-    method: The method name of the RPC.
-    timeout: An optional duration of time in seconds to allow for the RPC.
-    metadata: Optional :term:`metadata` to be transmitted to
-        the service-side of the RPC.
-    credentials: An optional CallCredentials for the RPC.
-    wait_for_ready: This is an EXPERIMENTAL argument. An optional
-            flag to enable :term:`wait_for_ready` mechanism.
-    compression: An element of grpc.compression, e.g.
-        grpc.compression.Gzip. This is an EXPERIMENTAL option.
+        method: The method name of the RPC.
+        timeout: An optional duration of time in seconds to allow for the RPC.
+        metadata: Optional :term:`metadata` to be transmitted to the
+                  service-side of the RPC.
+        credentials: An optional CallCredentials for the RPC.
+        wait_for_ready: This is an EXPERIMENTAL argument. An optional flag to
+                        enable :term:`wait_for_ready` mechanism.
+        compression: An element of grpc.compression, e.g. grpc.compression.Gzip.
+                     This is an EXPERIMENTAL option.
     """
 
-    method: str
-    timeout: Optional[int] = field(default=None)
-    metadata: List[Tuple[str, str]] = field(default_factory=list)
-    credentials: Optional[grpc.CallCredentials] = field(default=None)
-    wait_for_ready: Optional[bool] = field(default=None)
-    compression: Optional[grpc.Compression] = field(default=None)
+    pass
 
 
 class ClientInterceptor(

--- a/src/grpc_interceptor/client.py
+++ b/src/grpc_interceptor/client.py
@@ -2,9 +2,8 @@
 
 import abc
 from dataclasses import dataclass, field
-from typing import Callable, Iterator, List, Optional, Tuple
+from typing import Any, Callable, Iterator, List, Optional, Tuple
 
-from google.protobuf.message import Message
 import grpc
 
 
@@ -50,10 +49,10 @@ class ClientInterceptor(
     def intercept(
         self,
         call_details: ClientCallDetails,
-        request_iterator: Iterator[Message],
+        request_iterator: Iterator[Any],
         request_streaming: bool,
         response_streaming: bool,
-    ) -> Tuple[ClientCallDetails, Iterator[Message], Optional[Callable]]:
+    ) -> Tuple[ClientCallDetails, Iterator[Any], Optional[Callable]]:
         """Override this method to implement a custom interceptor.
 
         This method is called for all unary and streaming RPCs with the
@@ -65,7 +64,7 @@ class ClientInterceptor(
 
         Args:
             call_details (ClientCallDetails): Describes an RPC to be invoked
-            request_iterator (Iterator[Message]): RPC request messages
+            request_iterator (Iterator[Any]): RPC request messages
             request_streaming (bool): True if RPC is client or bi-directional streaming
             response_streaming (bool): True if PRC is server or bi-directional streaming
 
@@ -76,7 +75,7 @@ class ClientInterceptor(
         return call_details, request_iterator, None  # pragma: no cover
 
     def intercept_unary_unary(
-        self, continuation: Callable, call_details: ClientCallDetails, request: Message,
+        self, continuation: Callable, call_details: ClientCallDetails, request: Any,
     ):
         """Implementation of grpc.UnaryUnaryClientInterceptor.
 
@@ -97,7 +96,7 @@ class ClientInterceptor(
         return response
 
     def intercept_unary_stream(
-        self, continuation: Callable, call_details: ClientCallDetails, request: Message,
+        self, continuation: Callable, call_details: ClientCallDetails, request: Any,
     ):
         """Implementation of grpc.UnaryStreamClientInterceptor.
 
@@ -121,7 +120,7 @@ class ClientInterceptor(
         self,
         continuation: Callable,
         call_details: ClientCallDetails,
-        request_iterator: Iterator[Message],
+        request_iterator: Iterator[Any],
     ):
         """Implementation of grpc.StreamUnaryClientInterceptor.
 
@@ -145,7 +144,7 @@ class ClientInterceptor(
         self,
         continuation: Callable,
         call_details: ClientCallDetails,
-        request_iterator: Iterator[Message],
+        request_iterator: Iterator[Any],
     ):
         """Implementation of grpc.StreamStreamClientInterceptor.
 

--- a/src/grpc_interceptor/client.py
+++ b/src/grpc_interceptor/client.py
@@ -61,9 +61,9 @@ class ClientInterceptor(
             method: A function that proceeds with the invocation by executing the next
                 interceptor in the chain or invoking the actual RPC on the underlying
                 channel.
-            call_details: Describes an RPC to be invoked.
             request_or_iterator: RPC request message or iterator of request messages
                 for streaming requests.
+            call_details: Describes an RPC to be invoked.
 
         Returns:
             The type of the return should match the type of the return value received
@@ -75,7 +75,7 @@ class ClientInterceptor(
             The actual result from the RPC can be got by calling `.result()` on the
             value returned from `method`.
         """
-        return method(call_details, request_or_iterator)  # pragma: no cover
+        return method(request_or_iterator, call_details)  # pragma: no cover
 
     def intercept_unary_unary(
         self,
@@ -88,7 +88,7 @@ class ClientInterceptor(
         This is not part of the grpc_interceptor.ClientInterceptor API, but must have
         a public name. Do not override it, unless you know what you're doing.
         """
-        return self.intercept(continuation, request, call_details)
+        return self.intercept(_swap_args(continuation), request, call_details)
 
     def intercept_unary_stream(
         self,
@@ -101,7 +101,7 @@ class ClientInterceptor(
         This is not part of the grpc_interceptor.ClientInterceptor API, but must have
         a public name. Do not override it, unless you know what you're doing.
         """
-        return self.intercept(continuation, request, call_details)
+        return self.intercept(_swap_args(continuation), request, call_details)
 
     def intercept_stream_unary(
         self,
@@ -114,7 +114,7 @@ class ClientInterceptor(
         This is not part of the grpc_interceptor.ClientInterceptor API, but must have
         a public name. Do not override it, unless you know what you're doing.
         """
-        return self.intercept(continuation, request_iterator, call_details)
+        return self.intercept(_swap_args(continuation), request_iterator, call_details)
 
     def intercept_stream_stream(
         self,
@@ -127,4 +127,10 @@ class ClientInterceptor(
         This is not part of the grpc_interceptor.ClientInterceptor API, but must have
         a public name. Do not override it, unless you know what you're doing.
         """
-        return self.intercept(continuation, request_iterator, call_details)
+        return self.intercept(_swap_args(continuation), request_iterator, call_details)
+
+
+def _swap_args(fn: Callable[[Any, Any], Any]) -> Callable[[Any, Any], Any]:
+    def new_fn(x, y):
+        return fn(y, x)
+    return new_fn

--- a/src/grpc_interceptor/testing/__init__.py
+++ b/src/grpc_interceptor/testing/__init__.py
@@ -2,11 +2,22 @@
 
 from typing import Callable
 
-from grpc_interceptor.testing.dummy_client import dummy_client, DummyService
+from grpc_interceptor.testing.dummy_client import (
+    ClientCallDetails,
+    dummy_client,
+    DummyService,
+)
 from grpc_interceptor.testing.protos.dummy_pb2 import DummyRequest, DummyResponse
 
 
-__all__ = ["dummy_client", "DummyRequest", "DummyResponse", "DummyService", "raises"]
+__all__ = [
+    "ClientCallDetails",
+    "dummy_client",
+    "DummyRequest",
+    "DummyResponse",
+    "DummyService",
+    "raises",
+]
 
 
 def raises(e: Exception) -> Callable:

--- a/src/grpc_interceptor/testing/__init__.py
+++ b/src/grpc_interceptor/testing/__init__.py
@@ -10,7 +10,6 @@ from grpc_interceptor.testing.protos.dummy_pb2 import DummyRequest, DummyRespons
 
 
 __all__ = [
-    "ClientCallDetails",
     "dummy_client",
     "DummyRequest",
     "DummyResponse",

--- a/src/grpc_interceptor/testing/__init__.py
+++ b/src/grpc_interceptor/testing/__init__.py
@@ -3,7 +3,6 @@
 from typing import Callable
 
 from grpc_interceptor.testing.dummy_client import (
-    ClientCallDetails,
     dummy_client,
     DummyService,
 )

--- a/src/grpc_interceptor/testing/dummy_client.py
+++ b/src/grpc_interceptor/testing/dummy_client.py
@@ -1,5 +1,6 @@
 """Defines a service and client for testing interceptors."""
 
+from collections import namedtuple
 from concurrent import futures
 from contextlib import contextmanager
 import os
@@ -15,6 +16,39 @@ from grpc_interceptor.testing.protos import dummy_pb2_grpc
 from grpc_interceptor.testing.protos.dummy_pb2 import DummyRequest, DummyResponse
 
 SpecialCaseFunction = Callable[[str], str]
+
+
+class ClientCallDetails(
+    namedtuple(
+        "ClientCallDetails",
+        (
+            "method",
+            "timeout",
+            "metadata",
+            "credentials",
+            "wait_for_ready",
+            "compression",
+        ),
+    ),
+    grpc.ClientCallDetails,
+):
+    """Describes an RPC to be invoked.
+
+    This is an EXPERIMENTAL API.
+
+    Attributes:
+        method: The method name of the RPC.
+        timeout: An optional duration of time in seconds to allow for the RPC.
+        metadata: Optional :term:`metadata` to be transmitted to the
+                  service-side of the RPC.
+        credentials: An optional CallCredentials for the RPC.
+        wait_for_ready: This is an EXPERIMENTAL argument. An optional flag to
+                        enable :term:`wait_for_ready` mechanism.
+        compression: An element of grpc.compression, e.g. grpc.compression.Gzip.
+                     This is an EXPERIMENTAL option.
+    """
+
+    pass
 
 
 class DummyService(dummy_pb2_grpc.DummyServiceServicer):

--- a/src/grpc_interceptor/testing/dummy_client.py
+++ b/src/grpc_interceptor/testing/dummy_client.py
@@ -4,11 +4,12 @@ from concurrent import futures
 from contextlib import contextmanager
 import os
 from tempfile import gettempdir
-from typing import Callable, Dict, Iterable, List
+from typing import Callable, Dict, Iterable, List, Optional
 from uuid import uuid4
 
 import grpc
 
+from grpc_interceptor.client import ClientInterceptor
 from grpc_interceptor.server import ServerInterceptor
 from grpc_interceptor.testing.protos import dummy_pb2_grpc
 from grpc_interceptor.testing.protos.dummy_pb2 import DummyRequest, DummyResponse
@@ -27,27 +28,32 @@ class DummyService(dummy_pb2_grpc.DummyServiceServicer):
             This allows testing special cases, like raising exceptions.
     """
 
-    def __init__(self, special_cases: Dict[str, SpecialCaseFunction]):
+    def __init__(
+        self,
+        special_cases: Dict[str, SpecialCaseFunction],
+        context_cases: Optional[Dict[str, SpecialCaseFunction]] = None,
+    ):
         self._special_cases = special_cases
+        self._context_cases = context_cases
 
     def Execute(
         self, request: DummyRequest, context: grpc.ServicerContext
     ) -> DummyResponse:
         """Echo the input, or take on of the special cases actions."""
-        return DummyResponse(output=self._get_output(request))
+        return DummyResponse(output=self._get_output(request, context))
 
     def ExecuteClientStream(
         self, request_iter: Iterable[DummyRequest], context: grpc.ServicerContext
     ) -> DummyResponse:
         """Iterate over the input and concatenates the strings into the output."""
-        output = "".join(self._get_output(request) for request in request_iter)
+        output = "".join(self._get_output(request, context) for request in request_iter)
         return DummyResponse(output=output)
 
     def ExecuteServerStream(
         self, request: DummyRequest, context: grpc.ServicerContext
     ) -> Iterable[DummyResponse]:
         """Stream one character at a time from the input."""
-        for c in self._get_output(request):
+        for c in self._get_output(request, context):
             yield DummyResponse(output=c)
 
     def ExecuteClientServerStream(
@@ -55,27 +61,35 @@ class DummyService(dummy_pb2_grpc.DummyServiceServicer):
     ) -> Iterable[DummyResponse]:
         """Stream input to output."""
         for request in request_iter:
-            yield DummyResponse(output=self._get_output(request))
+            yield DummyResponse(output=self._get_output(request, context))
 
-    def _get_output(self, request: DummyRequest) -> str:
+    def _get_output(self, request: DummyRequest, context: grpc.ServicerContext) -> str:
         input = request.input
+
+        output = input
         if input in self._special_cases:
             output = self._special_cases[input](input)
-        else:
-            output = input
+        if self._context_cases and input in self._context_cases:
+            output = self._context_cases[input](context)
+
         return output
 
 
 @contextmanager
 def dummy_client(
     special_cases: Dict[str, SpecialCaseFunction],
-    interceptors: List[ServerInterceptor],
+    context_cases: Optional[Dict[str, SpecialCaseFunction]] = None,
+    interceptors: Optional[List[ServerInterceptor]] = None,
+    client_interceptors: Optional[List[ClientInterceptor]] = None,
 ):
     """A context manager that returns a gRPC client connected to a DummyService."""
+    if not interceptors:
+        interceptors = []
+
     server = grpc.server(
         futures.ThreadPoolExecutor(max_workers=1), interceptors=interceptors
     )
-    dummy_service = DummyService(special_cases)
+    dummy_service = DummyService(special_cases, context_cases)
     dummy_pb2_grpc.add_DummyServiceServicer_to_server(dummy_service, server)
 
     if os.name == "nt":  # pragma: no cover
@@ -89,6 +103,9 @@ def dummy_client(
     server.start()
 
     channel = grpc.insecure_channel(channel_descriptor)
+    if client_interceptors:
+        channel = grpc.intercept_channel(channel, *client_interceptors)
+
     client = dummy_pb2_grpc.DummyServiceStub(channel)
 
     try:

--- a/src/grpc_interceptor/testing/dummy_client.py
+++ b/src/grpc_interceptor/testing/dummy_client.py
@@ -1,6 +1,5 @@
 """Defines a service and client for testing interceptors."""
 
-from collections import namedtuple
 from concurrent import futures
 from contextlib import contextmanager
 import os
@@ -16,39 +15,6 @@ from grpc_interceptor.testing.protos import dummy_pb2_grpc
 from grpc_interceptor.testing.protos.dummy_pb2 import DummyRequest, DummyResponse
 
 SpecialCaseFunction = Callable[[str, grpc.ServicerContext], str]
-
-
-class ClientCallDetails(
-    namedtuple(
-        "ClientCallDetails",
-        (
-            "method",
-            "timeout",
-            "metadata",
-            "credentials",
-            "wait_for_ready",
-            "compression",
-        ),
-    ),
-    grpc.ClientCallDetails,
-):
-    """Describes an RPC to be invoked.
-
-    This is an EXPERIMENTAL API.
-
-    Attributes:
-        method: The method name of the RPC.
-        timeout: An optional duration of time in seconds to allow for the RPC.
-        metadata: Optional :term:`metadata` to be transmitted to the
-                  service-side of the RPC.
-        credentials: An optional CallCredentials for the RPC.
-        wait_for_ready: This is an EXPERIMENTAL argument. An optional flag to
-                        enable :term:`wait_for_ready` mechanism.
-        compression: An element of grpc.compression, e.g. grpc.compression.Gzip.
-                     This is an EXPERIMENTAL option.
-    """
-
-    pass
 
 
 class DummyService(dummy_pb2_grpc.DummyServiceServicer):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,163 @@
+"""Test cases for the grpc-interceptor base ClientInterceptor."""
+
+from typing import List, Tuple
+
+import pytest
+
+from grpc_interceptor import ClientCallDetails, ClientInterceptor
+from grpc_interceptor.testing import dummy_client, DummyRequest
+
+
+class MetadataInterceptor(ClientInterceptor):
+    """A test interceptor that injects invocation metadata."""
+
+    def __init__(self, metadata: List[Tuple[str, str]]):
+        self._metadata = metadata
+
+    def intercept(
+        self, call_details, request_iterator, request_streaming, response_streaming
+    ):
+        new_details = ClientCallDetails(
+            call_details.method,
+            call_details.timeout,
+            self._metadata,
+            call_details.credentials,
+            call_details.wait_for_ready,
+            call_details.compression,
+        )
+
+        return new_details, request_iterator, None
+
+
+class PostprocessInterceptor(ClientInterceptor):
+    """A test interceptor that logs results."""
+
+    def __init__(self):
+        import logging
+
+        self._log = logging.getLogger(__name__)
+
+    def intercept(
+        self, call_details, request_iterator, request_streaming, response_streaming
+    ):
+        def _unary_logger(outcome):
+            self._log.warning(outcome.result().output)
+            return outcome
+
+        def _stream_logger(response_iterator):
+            collected = ""
+            for response in response_iterator:
+                collected += response.output
+                yield response
+
+            self._log.warning(collected)
+
+        postprocess = _unary_logger
+        if response_streaming:
+            postprocess = _stream_logger
+
+        return call_details, request_iterator, postprocess
+
+
+@pytest.fixture
+def metadata_string():
+    """Expected joined metadata string."""
+    return "this_key:this_value"
+
+
+@pytest.fixture
+def metadata_client():
+    """Client with metadata interceptor."""
+    intr = MetadataInterceptor([("this_key", "this_value")])
+    interceptors = [intr]
+
+    context_cases = {
+        "metadata": lambda c: ",".join(
+            f"{key}:{value}" for key, value in c.invocation_metadata()
+        )
+    }
+    with dummy_client(
+        special_cases={}, context_cases=context_cases, client_interceptors=interceptors
+    ) as client:
+        yield client
+
+
+def test_metadata_unary(metadata_client, metadata_string):
+    """Invocation metadata should be added to the servicer context."""
+    unary_output = metadata_client.Execute(DummyRequest(input="metadata")).output
+    assert metadata_string in unary_output
+
+
+def test_metadata_server_stream(metadata_client, metadata_string):
+    """Invocation metadata should be added to the servicer context."""
+    server_stream_output = [
+        r.output
+        for r in metadata_client.ExecuteServerStream(DummyRequest(input="metadata"))
+    ]
+    assert (
+        "".join(server_stream_output[0 : len(metadata_string)])
+        == metadata_string  # noqa E203
+    )
+
+
+def test_metadata_client_stream(metadata_client, metadata_string):
+    """Invocation metadata should be added to the servicer context."""
+    client_stream_input = iter((DummyRequest(input="metadata"),))
+    client_stream_output = metadata_client.ExecuteClientStream(
+        client_stream_input
+    ).output
+    assert metadata_string in client_stream_output
+
+
+def test_metadata_client_server_stream(metadata_client, metadata_string):
+    """Invocation metadata should be added to the servicer context."""
+    stream_stream_input = iter((DummyRequest(input="metadata"),))
+    result = metadata_client.ExecuteClientServerStream(stream_stream_input)
+    stream_stream_output = [r.output for r in result]
+    assert metadata_string in stream_stream_output[0]
+
+
+@pytest.fixture
+def logged_string():
+    """Expected appended response string."""
+    return "logthisthing"
+
+
+@pytest.fixture
+def postprocess_client():
+    """Client with metadata interceptor."""
+    intr = PostprocessInterceptor()
+    interceptors = [intr]
+
+    with dummy_client(
+        special_cases={}, context_cases={}, client_interceptors=interceptors
+    ) as client:
+        yield client
+
+
+def test_postprocess_unary(caplog, postprocess_client, logged_string):
+    postprocess_client.Execute(DummyRequest(input=logged_string))
+    assert logged_string in caplog.text
+
+
+def test_postprocess_server_stream(caplog, postprocess_client, logged_string):
+    """Invocation metadata should be added to the servicer context."""
+    for _ in postprocess_client.ExecuteServerStream(DummyRequest(input=logged_string)):
+        pass
+
+    assert logged_string in caplog.text
+
+
+def test_postprocess_client_stream(caplog, postprocess_client, logged_string):
+    client_stream_input = iter((DummyRequest(input=logged_string),))
+    postprocess_client.ExecuteClientStream(client_stream_input)
+    assert logged_string in caplog.text
+
+
+def test_postprocess_client_server_stream(caplog, postprocess_client, logged_string):
+    """Invocation metadata should be added to the servicer context."""
+    stream_stream_input = iter((DummyRequest(input=logged_string),))
+    for _ in postprocess_client.ExecuteClientServerStream(stream_stream_input):
+        pass
+
+    assert logged_string in caplog.text

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,9 +14,7 @@ class MetadataInterceptor(ClientInterceptor):
     def __init__(self, metadata: List[Tuple[str, str]]):
         self._metadata = metadata
 
-    def intercept(
-        self, call_details, request_iterator, request_streaming, response_streaming
-    ):
+    def intercept(self, method, request_or_iterator, call_details):
         """Add invocation metadata to request."""
         new_details = ClientCallDetails(
             call_details.method,
@@ -27,39 +25,7 @@ class MetadataInterceptor(ClientInterceptor):
             call_details.compression,
         )
 
-        return new_details, request_iterator, None
-
-
-class PostprocessInterceptor(ClientInterceptor):
-    """A test interceptor that logs results."""
-
-    def __init__(self):
-        import logging
-
-        self._log = logging.getLogger(__name__)
-
-    def intercept(
-        self, call_details, request_iterator, request_streaming, response_streaming
-    ):
-        """Log response data."""
-
-        def _unary_logger(outcome):
-            self._log.warning(outcome.result().output)
-            return outcome
-
-        def _stream_logger(response_iterator):
-            collected = ""
-            for response in response_iterator:
-                collected += response.output
-                yield response
-
-            self._log.warning(collected)
-
-        postprocess = _unary_logger
-        if response_streaming:
-            postprocess = _stream_logger
-
-        return call_details, request_iterator, postprocess
+        return method(new_details, request_or_iterator)
 
 
 @pytest.fixture
@@ -74,13 +40,13 @@ def metadata_client():
     intr = MetadataInterceptor([("this_key", "this_value")])
     interceptors = [intr]
 
-    context_cases = {
-        "metadata": lambda c: ",".join(
+    special_cases = {
+        "metadata": lambda _, c: ",".join(
             f"{key}:{value}" for key, value in c.invocation_metadata()
         )
     }
     with dummy_client(
-        special_cases={}, context_cases=context_cases, client_interceptors=interceptors
+        special_cases=special_cases, client_interceptors=interceptors
     ) as client:
         yield client
 
@@ -118,51 +84,3 @@ def test_metadata_client_server_stream(metadata_client, metadata_string):
     result = metadata_client.ExecuteClientServerStream(stream_stream_input)
     stream_stream_output = [r.output for r in result]
     assert metadata_string in stream_stream_output[0]
-
-
-@pytest.fixture
-def logged_string():
-    """Expected logged response string."""
-    return "logthisthing"
-
-
-@pytest.fixture
-def postprocess_client():
-    """Client with postprocess interceptor."""
-    intr = PostprocessInterceptor()
-    interceptors = [intr]
-
-    with dummy_client(
-        special_cases={}, context_cases={}, client_interceptors=interceptors
-    ) as client:
-        yield client
-
-
-def test_postprocess_unary(caplog, postprocess_client, logged_string):
-    """Response output field should be logged."""
-    postprocess_client.Execute(DummyRequest(input=logged_string))
-    assert logged_string in caplog.text
-
-
-def test_postprocess_server_stream(caplog, postprocess_client, logged_string):
-    """Response output fields should be concatenated and logged."""
-    for _ in postprocess_client.ExecuteServerStream(DummyRequest(input=logged_string)):
-        pass
-
-    assert logged_string in caplog.text
-
-
-def test_postprocess_client_stream(caplog, postprocess_client, logged_string):
-    """Response output field should be logged."""
-    client_stream_input = iter((DummyRequest(input=logged_string),))
-    postprocess_client.ExecuteClientStream(client_stream_input)
-    assert logged_string in caplog.text
-
-
-def test_postprocess_client_server_stream(caplog, postprocess_client, logged_string):
-    """Response output fields should be concatenated and logged."""
-    stream_stream_input = iter((DummyRequest(input=logged_string),))
-    for _ in postprocess_client.ExecuteClientServerStream(stream_stream_input):
-        pass
-
-    assert logged_string in caplog.text

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,7 +20,7 @@ class MetadataInterceptor(ClientInterceptor):
     def intercept(self, method, request_or_iterator, call_details):
         """Add invocation metadata to request."""
         new_details = call_details._replace(metadata=self._metadata)
-        return method(new_details, request_or_iterator)
+        return method(request_or_iterator, new_details)
 
 
 class CodeCountInterceptor(ClientInterceptor):
@@ -31,7 +31,7 @@ class CodeCountInterceptor(ClientInterceptor):
 
     def intercept(self, method, request_or_iterator, call_details):
         """Call continuation and count status codes."""
-        future = method(call_details, request_or_iterator)
+        future = method(request_or_iterator, call_details)
         self.counts[future.code()] += 1
         return future
 
@@ -46,7 +46,7 @@ class RetryInterceptor(ClientInterceptor):
         """Call the continuation and retry up to retries times if it fails."""
         tries_remaining = 1 + self._retries
         while 0 < tries_remaining:
-            future = method(call_details, request_or_iterator)
+            future = method(request_or_iterator, call_details)
             try:
                 future.result()
                 return future
@@ -90,7 +90,7 @@ class CachingInterceptor(ClientInterceptor):
             cache_key = request_or_iterator.input
 
         if cache_key not in self._cache:
-            self._cache[cache_key] = method(call_details, request_or_iterator)
+            self._cache[cache_key] = method(request_or_iterator, call_details)
 
         return self._cache[cache_key]
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,8 +4,8 @@ from typing import List, Tuple
 
 import pytest
 
-from grpc_interceptor import ClientInterceptor
-from grpc_interceptor.testing import ClientCallDetails, dummy_client, DummyRequest
+from grpc_interceptor import ClientCallDetails, ClientInterceptor
+from grpc_interceptor.testing import dummy_client, DummyRequest
 
 
 class MetadataInterceptor(ClientInterceptor):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,8 +4,8 @@ from typing import List, Tuple
 
 import pytest
 
-from grpc_interceptor import ClientCallDetails, ClientInterceptor
-from grpc_interceptor.testing import dummy_client, DummyRequest
+from grpc_interceptor import ClientInterceptor
+from grpc_interceptor.testing import ClientCallDetails, dummy_client, DummyRequest
 
 
 class MetadataInterceptor(ClientInterceptor):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,11 +1,14 @@
 """Test cases for the grpc-interceptor base ClientInterceptor."""
 
+from collections import defaultdict
+import itertools
 from typing import List, Tuple
 
+import grpc
 import pytest
 
-from grpc_interceptor import ClientCallDetails, ClientInterceptor
-from grpc_interceptor.testing import dummy_client, DummyRequest
+from grpc_interceptor import ClientInterceptor
+from grpc_interceptor.testing import dummy_client, DummyRequest, raises
 
 
 class MetadataInterceptor(ClientInterceptor):
@@ -16,16 +19,80 @@ class MetadataInterceptor(ClientInterceptor):
 
     def intercept(self, method, request_or_iterator, call_details):
         """Add invocation metadata to request."""
-        new_details = ClientCallDetails(
-            call_details.method,
-            call_details.timeout,
-            self._metadata,
-            call_details.credentials,
-            call_details.wait_for_ready,
-            call_details.compression,
-        )
-
+        new_details = call_details._replace(metadata=self._metadata)
         return method(new_details, request_or_iterator)
+
+
+class CodeCountInterceptor(ClientInterceptor):
+    """Test interceptor that counts status codes returned by the server."""
+
+    def __init__(self):
+        self.counts = defaultdict(int)
+
+    def intercept(self, method, request_or_iterator, call_details):
+        """Call continuation and count status codes."""
+        future = method(call_details, request_or_iterator)
+        self.counts[future.code()] += 1
+        return future
+
+
+class RetryInterceptor(ClientInterceptor):
+    """Test interceptor that retries failed RPCs."""
+
+    def __init__(self, retries):
+        self._retries = retries
+
+    def intercept(self, method, request_or_iterator, call_details):
+        """Call the continuation and retry up to retries times if it fails."""
+        tries_remaining = 1 + self._retries
+        while 0 < tries_remaining:
+            future = method(call_details, request_or_iterator)
+            try:
+                future.result()
+                return future
+            except Exception:
+                tries_remaining -= 1
+
+        return future
+
+
+class CrashingService:
+    """Special case function that raises a given number of times before succeeding."""
+
+    DEFAULT_EXCEPTION = ValueError("oops")
+
+    def __init__(self, num_crashes, success_value="OK", exception=DEFAULT_EXCEPTION):
+        self._num_crashes = num_crashes
+        self._success_value = success_value
+        self._exception = exception
+
+    def __call__(self, *args, **kwargs):
+        """Raise the first num_crashes times called, then return success_value."""
+        if 0 < self._num_crashes:
+            self._num_crashes -= 1
+            raise self._exception
+
+        return self._success_value
+
+
+class CachingInterceptor(ClientInterceptor):
+    """A test interceptor that caches responses based on input string."""
+
+    def __init__(self):
+        self._cache = {}
+
+    def intercept(self, method, request_or_iterator, call_details):
+        """Cache responses based on input string."""
+        if hasattr(request_or_iterator, "__iter__"):
+            request_or_iterator, copy_iterator = itertools.tee(request_or_iterator)
+            cache_key = tuple(r.input for r in copy_iterator)
+        else:
+            cache_key = request_or_iterator.input
+
+        if cache_key not in self._cache:
+            self._cache[cache_key] = method(call_details, request_or_iterator)
+
+        return self._cache[cache_key]
 
 
 @pytest.fixture
@@ -84,3 +151,80 @@ def test_metadata_client_server_stream(metadata_client, metadata_string):
     result = metadata_client.ExecuteClientServerStream(stream_stream_input)
     stream_stream_output = [r.output for r in result]
     assert metadata_string in stream_stream_output[0]
+
+
+def test_code_counting():
+    """Access to code on call details works correctly."""
+    interceptor = CodeCountInterceptor()
+    special_cases = {"error": raises(ValueError("oops"))}
+    with dummy_client(
+        special_cases=special_cases, client_interceptors=[interceptor]
+    ) as client:
+        assert interceptor.counts == {}
+        client.Execute(DummyRequest(input="foo"))
+        assert interceptor.counts == {grpc.StatusCode.OK: 1}
+        with pytest.raises(grpc.RpcError):
+            client.Execute(DummyRequest(input="error"))
+        assert interceptor.counts == {grpc.StatusCode.OK: 1, grpc.StatusCode.UNKNOWN: 1}
+
+
+def test_basic_retry():
+    """Calling the continuation multiple times should work."""
+    interceptor = RetryInterceptor(retries=1)
+    special_cases = {"error_once": CrashingService(num_crashes=1)}
+    with dummy_client(
+        special_cases=special_cases, client_interceptors=[interceptor]
+    ) as client:
+        assert client.Execute(DummyRequest(input="error_once")).output == "OK"
+
+
+def test_failed_retry():
+    """The interceptor can return failed futures."""
+    interceptor = RetryInterceptor(retries=1)
+    special_cases = {"error_twice": CrashingService(num_crashes=2)}
+    with dummy_client(
+        special_cases=special_cases, client_interceptors=[interceptor]
+    ) as client:
+        with pytest.raises(grpc.RpcError):
+            client.Execute(DummyRequest(input="error_twice"))
+
+
+def test_chaining():
+    """Chaining interceptors should work."""
+    retry_interceptor = RetryInterceptor(retries=1)
+    code_count_interceptor = CodeCountInterceptor()
+    interceptors = [retry_interceptor, code_count_interceptor]
+    special_cases = {"error_once": CrashingService(num_crashes=1)}
+    with dummy_client(
+        special_cases=special_cases, client_interceptors=interceptors
+    ) as client:
+        assert code_count_interceptor.counts == {}
+        assert client.Execute(DummyRequest(input="error_once")).output == "OK"
+        assert code_count_interceptor.counts == {
+            grpc.StatusCode.OK: 1,
+            grpc.StatusCode.UNKNOWN: 1,
+        }
+
+
+def test_caching():
+    """Caching calls (not calling the continuation) should work."""
+    caching_interceptor = CachingInterceptor()
+    # Use this to test how many times the continuation is called.
+    code_count_interceptor = CodeCountInterceptor()
+    interceptors = [caching_interceptor, code_count_interceptor]
+    with dummy_client(special_cases={}, client_interceptors=interceptors) as client:
+        assert code_count_interceptor.counts == {}
+        assert client.Execute(DummyRequest(input="hello")).output == "hello"
+        assert code_count_interceptor.counts == {grpc.StatusCode.OK: 1}
+        assert client.Execute(DummyRequest(input="hello")).output == "hello"
+        assert code_count_interceptor.counts == {grpc.StatusCode.OK: 1}
+        assert client.Execute(DummyRequest(input="goodbye")).output == "goodbye"
+        assert code_count_interceptor.counts == {grpc.StatusCode.OK: 2}
+        # Try streaming requests
+        inputs = ["foo", "bar"]
+        input_iter = (DummyRequest(input=input) for input in inputs)
+        assert client.ExecuteClientStream(input_iter).output == "foobar"
+        assert code_count_interceptor.counts == {grpc.StatusCode.OK: 3}
+        input_iter = (DummyRequest(input=input) for input in inputs)
+        assert client.ExecuteClientStream(input_iter).output == "foobar"
+        assert code_count_interceptor.counts == {grpc.StatusCode.OK: 3}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -130,10 +130,7 @@ def test_metadata_server_stream(metadata_client, metadata_string):
         r.output
         for r in metadata_client.ExecuteServerStream(DummyRequest(input="metadata"))
     ]
-    assert (
-        "".join(server_stream_output[0 : len(metadata_string)])  # noqa E203
-        == metadata_string
-    )
+    assert metadata_string in "".join(server_stream_output)
 
 
 def test_metadata_client_stream(metadata_client, metadata_string):
@@ -150,7 +147,7 @@ def test_metadata_client_server_stream(metadata_client, metadata_string):
     stream_stream_input = iter((DummyRequest(input="metadata"),))
     result = metadata_client.ExecuteClientServerStream(stream_stream_input)
     stream_stream_output = [r.output for r in result]
-    assert metadata_string in stream_stream_output[0]
+    assert metadata_string in "".join(stream_stream_output)
 
 
 def test_code_counting():


### PR DESCRIPTION
Thanks for putting this package together, it really removes a lot of the headache in implementing server interceptors! This PR adds similar support for custom client interceptors by extending a base class with a single abstract `intercept` method. This also adds an optional `context_cases` to the dummy client to support acting on the `ServicerContext` in tests. In my case I used this to pull injected invocation metadata into the response so I could assert on it from there.

You did a great job getting this covered and documented. I tried to also check all those boxes as to not taint your work 😉 

Let me know what you think and thanks again!
