### PR TITLE
ExceptionToStatusInterceptor: Fix streaming responses

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,12 +3,17 @@ on: [push, pull_request]
 jobs:
     tests:
         strategy:
+            fail-fast: false
             matrix:
                 platform: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: ['3.6', '3.9']
-                exclude:
-                - platform: macos-latest
+                python-version: ['3.9']
+                include:  # Oldest versions >=3.6 that are available for each platform
+                - platform: ubuntu-latest
                   python-version: 3.6
+                - platform: macos-latest
+                  python-version: 3.7
+                - platform: windows-latest
+                  python-version: 3.7
         name: Python ${{matrix.python-version}} ${{matrix.platform}}
         runs-on: ${{matrix.platform}}
         steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "grpc-interceptor"
-version = "0.13.1"
+version = "0.13.2"
 description = "Simplifies gRPC interceptors"
 license = "MIT"
 readme = "README.md"

--- a/src/grpc_interceptor/exception_to_status.py
+++ b/src/grpc_interceptor/exception_to_status.py
@@ -1,6 +1,7 @@
 """ExceptionToStatusInterceptor catches GrpcException and sets the gRPC context."""
 
-from typing import Any, Callable, Optional
+from contextlib import contextmanager
+from typing import Any, Callable, Generator, Optional
 
 import grpc
 
@@ -31,6 +32,29 @@ class ExceptionToStatusInterceptor(ServerInterceptor):
             raise ValueError("The status code for unknown exceptions cannot be OK")
         self._status_on_unknown_exception = status_on_unknown_exception
 
+    def _generate_responses(self, context, responses):
+        """Yield all the responses, but check for errors along the way"""
+        with self._handle_exceptions(context, reraise=False):
+            yield from responses
+
+    @contextmanager
+    def _handle_exceptions(self, context, *, reraise: bool):
+        try:
+            yield
+        except GrpcException as e:
+            context.set_code(e.status_code)
+            context.set_details(e.details)
+            if reraise:
+                raise
+        except Exception as e:
+            if self._status_on_unknown_exception is not None:
+                context.set_code(self._status_on_unknown_exception)
+                context.set_details(repr(e))
+                if reraise:
+                    raise
+            else:
+                raise
+
     def intercept(
         self,
         method: Callable,
@@ -39,14 +63,12 @@ class ExceptionToStatusInterceptor(ServerInterceptor):
         method_name: str,
     ) -> Any:
         """Do not call this directly; use the interceptor kwarg on grpc.server()."""
-        try:
-            return method(request, context)
-        except GrpcException as e:
-            context.set_code(e.status_code)
-            context.set_details(e.details)
-            raise
-        except Exception as e:
-            if self._status_on_unknown_exception is not None:
-                context.set_code(self._status_on_unknown_exception)
-                context.set_details(repr(e))
-            raise
+        with self._handle_exceptions(context, reraise=True):
+            responses = method(request, context)
+
+        if isinstance(responses, Generator):
+            # multiple responses; return a generator
+            return self._generate_responses(context, responses)
+        else:
+            # return a single response
+            return responses

--- a/src/grpc_interceptor/exception_to_status.py
+++ b/src/grpc_interceptor/exception_to_status.py
@@ -33,7 +33,7 @@ class ExceptionToStatusInterceptor(ServerInterceptor):
         self._status_on_unknown_exception = status_on_unknown_exception
 
     def _generate_responses(self, context, responses):
-        """Yield all the responses, but check for errors along the way"""
+        """Yield all the responses, but check for errors along the way."""
         with self._handle_exceptions(context, reraise=False):
             yield from responses
 

--- a/src/grpc_interceptor/testing/dummy_client.py
+++ b/src/grpc_interceptor/testing/dummy_client.py
@@ -29,7 +29,8 @@ class DummyService(dummy_pb2_grpc.DummyServiceServicer):
     """
 
     def __init__(
-        self, special_cases: Dict[str, SpecialCaseFunction],
+        self,
+        special_cases: Dict[str, SpecialCaseFunction],
     ):
         self._special_cases = special_cases
 

--- a/tests/test_exception_to_status.py
+++ b/tests/test_exception_to_status.py
@@ -118,6 +118,19 @@ def test_all_exceptions(interceptors):
     assert len(seen_details) == len(all_status_codes)
 
 
+def test_exception_in_streaming_response(interceptors):
+    """Exceptions are raised correctly from streaming responses."""
+
+    with dummy_client(
+        special_cases={"error": raises(gx.NotFound("not found!"))},
+        interceptors=interceptors,
+    ) as client:
+        with pytest.raises(grpc.RpcError) as e:
+            list(client.ExecuteServerStream(DummyRequest(input="error")))
+        assert e.value.code() == grpc.StatusCode.NOT_FOUND
+        assert e.value.details() == "not found!"
+
+
 def _snake_to_camel(s: str) -> str:
     return "".join([p.title() for p in s.split("_")])
 

--- a/tests/test_exception_to_status.py
+++ b/tests/test_exception_to_status.py
@@ -120,7 +120,6 @@ def test_all_exceptions(interceptors):
 
 def test_exception_in_streaming_response(interceptors):
     """Exceptions are raised correctly from streaming responses."""
-
     with dummy_client(
         special_cases={"error": raises(gx.NotFound("not found!"))},
         interceptors=interceptors,


### PR DESCRIPTION
In streaming responses, `ExceptionToStatusInterceptor` noops, because the
intercept() method is called once and returns a generator before the
exception handling can take effect.

This change alters the intercept() method to additionally apply
exception handling inside the generator function it returns.

I'm not sure if this is the *correct* fix; it seems like maybe this
behaviour should live outside the intercept() function somehow. But it
fixes the issue for me and has a test.

Fixes #10 