### PR TITLE
Add support for Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,14 +6,7 @@ jobs:
             fail-fast: false
             matrix:
                 platform: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: ['3.9']
-                include:
-                - platform: ubuntu-latest
-                  python-version: 3.7
-                - platform: macos-latest
-                  python-version: 3.7
-                - platform: windows-latest
-                  python-version: 3.7
+                python-version: ['3.11', '3.10', '3.9', '3.8', '3.7']
         name: Python ${{matrix.python-version}} ${{matrix.platform}}
         runs-on: ${{matrix.platform}}
         steps:

--- a/noxfile.py
+++ b/noxfile.py
@@ -11,8 +11,8 @@ import toml
 
 
 nox.options.sessions = "lint", "mypy", "tests", "xdoctest", "mindeps"
-PY_VERSIONS = ["3.9", "3.8", "3.7"]
-PY_LATEST = "3.9"
+PY_VERSIONS = ["3.11", "3.10", "3.9", "3.8", "3.7"]
+PY_LATEST = "3.10"
 
 
 @nox.session(python=PY_VERSIONS)


### PR DESCRIPTION
Well… that didn’t go too well. Leaving this as a Draft for now.