### PR TITLE
Fix wrong status code if context.abort has been called

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "grpc-interceptor"
-version = "0.15.2"
+version = "0.15.3"
 description = "Simplifies gRPC interceptors"
 license = "MIT"
 readme = "README.md"

--- a/src/grpc_interceptor/exception_to_status.py
+++ b/src/grpc_interceptor/exception_to_status.py
@@ -33,9 +33,9 @@ class ExceptionToStatusInterceptor(ServerInterceptor):
         status_on_unknown_exception: Specify what to do if an exception which is
             not a subclass of GrpcException is raised. If None, do nothing (by
             default, grpc will set the status to UNKNOWN). If not None, then the
-            status code will be set to this value. It must not be OK. The details
-            will be set to the value of repr(e), where e is the exception. In any
-            case, the exception will be propagated.
+            status code will be set to this value if `context.abort` hasn't been called 
+            earlier. It must not be OK. The details will be set to the value of repr(e),
+            where e is the exception. In any case, the exception will be propagated.
 
     Raises:
         ValueError: If status_code is OK.
@@ -93,7 +93,7 @@ class ExceptionToStatusInterceptor(ServerInterceptor):
         """
         if isinstance(ex, GrpcException):
             context.abort(ex.status_code, ex.details)
-        else:
+        elif not context.code():
             if self._status_on_unknown_exception is not None:
                 context.abort(self._status_on_unknown_exception, repr(ex))
         raise ex

--- a/src/grpc_interceptor/exception_to_status.py
+++ b/src/grpc_interceptor/exception_to_status.py
@@ -33,7 +33,7 @@ class ExceptionToStatusInterceptor(ServerInterceptor):
         status_on_unknown_exception: Specify what to do if an exception which is
             not a subclass of GrpcException is raised. If None, do nothing (by
             default, grpc will set the status to UNKNOWN). If not None, then the
-            status code will be set to this value if `context.abort` hasn't been called 
+            status code will be set to this value if `context.abort` hasn't been called
             earlier. It must not be OK. The details will be set to the value of repr(e),
             where e is the exception. In any case, the exception will be propagated.
 

--- a/src/grpc_interceptor/testing/dummy_client.py
+++ b/src/grpc_interceptor/testing/dummy_client.py
@@ -1,9 +1,9 @@
 """Defines a service and client for testing interceptors."""
 
-from inspect import iscoroutine
 import asyncio
 from concurrent import futures
 from contextlib import contextmanager
+from inspect import iscoroutine
 from threading import Event, Thread
 from typing import (
     Any,
@@ -37,7 +37,7 @@ class _SpecialCaseMixin:
             output = self._special_cases[input](input, context)
 
         return output
-    
+
     async def _get_output_async(
         self,
         request: DummyRequest,
@@ -52,6 +52,7 @@ class _SpecialCaseMixin:
                 output = await output
 
         return output
+
 
 class DummyService(dummy_pb2_grpc.DummyServiceServicer, _SpecialCaseMixin):
     """A gRPC service used for testing.
@@ -122,9 +123,10 @@ class AsyncDummyService(dummy_pb2_grpc.DummyServiceServicer, _SpecialCaseMixin):
         context: grpc_aio.ServicerContext,
     ) -> DummyResponse:
         """Iterate over the input and concatenates the strings into the output."""
-        output = "".join(
-            [await self._get_output_async(request, context) async for request in request_iter]
-        )
+        output = "".join([
+            await self._get_output_async(request, context)
+            async for request in request_iter
+        ])  # noqa: E501
         return DummyResponse(output=output)
 
     async def ExecuteServerStream(

--- a/src/grpc_interceptor/testing/dummy_client.py
+++ b/src/grpc_interceptor/testing/dummy_client.py
@@ -38,7 +38,11 @@ class _SpecialCaseMixin:
 
         return output
     
-    async def _get_output_async(self, request: DummyRequest, context: grpc.ServicerContext) -> str:
+    async def _get_output_async(
+        self,
+        request: DummyRequest,
+        context: grpc_aio.ServicerContext
+    ) -> str:
         input = request.input
 
         output = input

--- a/tests/test_exception_to_status.py
+++ b/tests/test_exception_to_status.py
@@ -1,8 +1,9 @@
 """Test cases for ExceptionToStatusInterceptor."""
 import re
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Any
 
 import grpc
+from grpc import aio as grpc_aio
 import pytest
 
 from grpc_interceptor import exceptions as gx
@@ -154,6 +155,26 @@ def test_non_grpc_exception_with_override(aio):
         assert e.value.code() == grpc.StatusCode.INTERNAL
         assert re.fullmatch(r"ValueError\('oops',?\)", e.value.details())
 
+
+@pytest.mark.parametrize("aio", [False, True])
+def test_aborted_context(aio):
+    def error(request: Any, context: grpc.ServicerContext) -> None:
+        context.abort(grpc.StatusCode.RESOURCE_EXHAUSTED, 'resource exhausted')
+        
+    async def async_error(request: Any, context: grpc_aio.ServicerContext) -> None:        
+        await context.abort(grpc.StatusCode.RESOURCE_EXHAUSTED, 'resource exhausted')
+        
+    interceptors = _get_interceptors(aio, grpc.StatusCode.INTERNAL)
+    special_cases = {
+        "error": async_error if aio else error
+    }
+    
+    with dummy_client(
+        special_cases=special_cases, interceptors=interceptors, aio_server=aio
+    ) as client:
+        with pytest.raises(grpc.RpcError) as e:
+            client.Execute(DummyRequest(input="error"))
+        assert e.value.code() == grpc.StatusCode.RESOURCE_EXHAUSTED
 
 def test_override_with_ok():
     """We cannot set the default status code to OK."""


### PR DESCRIPTION
When **context.abort** is invoked prior to the interceptor being reached, the status code specified in **context.abort** should be used, taking precedence over **status_on_unknown_exception**.

### Example:

Given the use of the following interceptor:
```python
ExceptionToStatusInterceptor(status_on_unknown_exception=grpc.StatusCode.INTERNAL)
```

If context.abort is implemented somewhere in the service as:
```python
context.abort(grpc.StatusCode.RESOURCE_EXHAUSTED, 'resource exhausted')
```

### Expected Behavior:
The service should return an error with the status code set to grpc.StatusCode.RESOURCE_EXHAUSTED.