### PR TITLE
Replace poetry with poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,5 +50,5 @@ omit = ["*_pb2.py", "*_pb2_grpc.py"]
 show_missing = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
While poetry is a user-facing tool for managing a project's dependencies, [poetry-core](https://github.com/python-poetry/poetry-core) is the lighter weight PEP 517 build backend that can be used in pyproject.toml. This enables using another PEP 517 build front-end (such as [`build`](https://pypa-build.readthedocs.io/en/latest/)) to build the package without also depending on all of poetry.