### PR TITLE
fix: update some types and add symmetry between the sync and async server interceptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,28 +41,28 @@ class ExceptionToStatusInterceptor(ServerInterceptor):
     def intercept(
         self,
         method: Callable,
-        request: Any,
+        request_or_iterator: Any,
         context: grpc.ServicerContext,
         method_name: str,
     ) -> Any:
         """Override this method to implement a custom interceptor.
-         You should call method(request, context) to invoke the
+         You should call method(request_or_iterator, context) to invoke the
          next handler (either the RPC method implementation, or the
          next interceptor in the list).
          Args:
              method: The next interceptor, or method implementation.
-             request: The RPC request, as a protobuf message.
+             request_or_iterator: The RPC request, as a protobuf message.
              context: The ServicerContext pass by gRPC to the service.
              method_name: A string of the form
                  "/protobuf.package.Service/Method"
          Returns:
              This should generally return the result of
-             method(request, context), which is typically the RPC
+             method(request_or_iterator, context), which is typically the RPC
              method response, as a protobuf message. The interceptor
              is free to modify this in some way, however.
          """
         try:
-            return method(request, context)
+            return method(request_or_iterator, context)
         except GrpcException as e:
             context.set_code(e.status_code)
             context.set_details(e.details)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -77,31 +77,31 @@ To define your own server interceptor (we can use a simplified version of
        def intercept(
            self,
            method: Callable,
-           request: Any,
+           request_or_iterator: Any,
            context: grpc.ServicerContext,
            method_name: str,
        ) -> Any:
            """Override this method to implement a custom interceptor.
 
-            You should call method(request, context) to invoke the
+            You should call method(request_or_iterator, context) to invoke the
             next handler (either the RPC method implementation, or the
             next interceptor in the list).
 
             Args:
                 method: The next interceptor, or method implementation.
-                request: The RPC request, as a protobuf message.
+                request_or_iterator: The RPC request, as a protobuf message.
                 context: The ServicerContext pass by gRPC to the service.
                 method_name: A string of the form
                     "/protobuf.package.Service/Method"
 
             Returns:
                 This should generally return the result of
-                method(request, context), which is typically the RPC
+                method(request_or_iterator, context), which is typically the RPC
                 method response, as a protobuf message. The interceptor
                 is free to modify this in some way, however.
             """
            try:
-               return method(request, context)
+               return method(request_or_iterator, context)
            except GrpcException as e:
                context.set_code(e.status_code)
                context.set_details(e.details)

--- a/src/grpc_interceptor/exception_to_status.py
+++ b/src/grpc_interceptor/exception_to_status.py
@@ -10,6 +10,7 @@ from typing import (
     Generator,
     Iterable,
     Iterator,
+    NoReturn,
     Optional,
 )
 
@@ -73,7 +74,7 @@ class ExceptionToStatusInterceptor(ServerInterceptor):
         request_or_iterator: Any,
         context: grpc.ServicerContext,
         method_name: str,
-    ) -> None:
+    ) -> NoReturn:
         """Override this if extending ExceptionToStatusInterceptor.
 
         This will get called when an exception is raised while handling the RPC.
@@ -152,7 +153,7 @@ class AsyncExceptionToStatusInterceptor(AsyncServerInterceptor):
         request_or_iterator: Any,
         context: grpc_aio.ServicerContext,
         method_name: str,
-    ) -> None:
+    ) -> NoReturn:
         """Override this if extending ExceptionToStatusInterceptor.
 
         This will get called when an exception is raised while handling the RPC.
@@ -172,7 +173,7 @@ class AsyncExceptionToStatusInterceptor(AsyncServerInterceptor):
         """
         if isinstance(ex, GrpcException):
             await context.abort(ex.status_code, ex.details)
-        else:
+        elif not context.code():
             if self._status_on_unknown_exception is not None:
                 await context.abort(self._status_on_unknown_exception, repr(ex))
         raise ex

--- a/src/grpc_interceptor/server.py
+++ b/src/grpc_interceptor/server.py
@@ -24,8 +24,8 @@ class ServerInterceptor(grpc.ServerInterceptor, metaclass=abc.ABCMeta):
     ) -> Any:  # pragma: no cover
         """Override this method to implement a custom interceptor.
 
-        You should call method(request, context) to invoke the next handler (either the
-        RPC method implementation, or the next interceptor in the list).
+        You should call method(request_or_iterator, context) to invoke the next handler
+        (either the RPC method implementation, or the next interceptor in the list).
 
         Args:
             method: Either the RPC method implementation, or the next interceptor in
@@ -37,7 +37,7 @@ class ServerInterceptor(grpc.ServerInterceptor, metaclass=abc.ABCMeta):
             method_name: A string of the form "/protobuf.package.Service/Method"
 
         Returns:
-            This should generally return the result of method(request, context), which
+            This should return the result of method(request, context), which
             is typically the RPC method response, as a protobuf message, or an
             iterator of protobuf messages for streaming responses. The interceptor is
             free to modify this in some way, however.
@@ -90,7 +90,7 @@ class AsyncServerInterceptor(grpc_aio.ServerInterceptor, metaclass=abc.ABCMeta):
     ) -> Any:  # pragma: no cover
         """Override this method to implement a custom interceptor.
 
-        You should call await method(request_or_iterator, context) to invoke the next handler
+        You should await method(request_or_iterator, context) to invoke the next handler
         (either the RPC method implementation, or the next interceptor in the list).
 
         Args:
@@ -103,7 +103,7 @@ class AsyncServerInterceptor(grpc_aio.ServerInterceptor, metaclass=abc.ABCMeta):
             method_name: A string of the form "/protobuf.package.Service/Method"
 
         Returns:
-            This should generally return the result of await method(request_or_iterator, context),
+            This should return the result of method(request_or_iterator, context),
             which is typically the RPC method response, as a protobuf message. The
             interceptor is free to modify this in some way, however.
         """

--- a/src/grpc_interceptor/server.py
+++ b/src/grpc_interceptor/server.py
@@ -84,28 +84,30 @@ class AsyncServerInterceptor(grpc_aio.ServerInterceptor, metaclass=abc.ABCMeta):
     async def intercept(
         self,
         method: Callable,
-        request: Any,
+        request_or_iterator: Any,
         context: grpc_aio.ServicerContext,
         method_name: str,
     ) -> Any:  # pragma: no cover
         """Override this method to implement a custom interceptor.
 
-        You should call await method(request, context) to invoke the next handler
+        You should call await method(request_or_iterator, context) to invoke the next handler
         (either the RPC method implementation, or the next interceptor in the list).
 
         Args:
             method: Either the RPC method implementation, or the next interceptor in
                 the chain.
-            request: The RPC request, as a protobuf message.
+            request_or_iterator: The RPC request, as a protobuf message if it is a
+                unary request, or an iterator of protobuf messages if it is a streaming
+                request.
             context: The ServicerContext pass by gRPC to the service.
             method_name: A string of the form "/protobuf.package.Service/Method"
 
         Returns:
-            This should generally return the result of await method(request, context),
+            This should generally return the result of await method(request_or_iterator, context),
             which is typically the RPC method response, as a protobuf message. The
             interceptor is free to modify this in some way, however.
         """
-        response_or_iterator = method(request, context)
+        response_or_iterator = method(request_or_iterator, context)
         if hasattr(response_or_iterator, "__aiter__"):
             return response_or_iterator
         else:

--- a/src/grpc_interceptor/testing/dummy_client.py
+++ b/src/grpc_interceptor/testing/dummy_client.py
@@ -14,6 +14,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Union
 )
 
 import grpc
@@ -23,7 +24,9 @@ from grpc_interceptor.server import AsyncServerInterceptor, grpc_aio, ServerInte
 from grpc_interceptor.testing.protos import dummy_pb2_grpc
 from grpc_interceptor.testing.protos.dummy_pb2 import DummyRequest, DummyResponse
 
-SpecialCaseFunction = Callable[[str, grpc.ServicerContext], str]
+SpecialCaseFunction = Callable[
+    [str, Union[grpc.ServicerContext, grpc_aio.ServicerContext]], str
+]
 
 
 class _SpecialCaseMixin:

--- a/tests/test_exception_to_status.py
+++ b/tests/test_exception_to_status.py
@@ -176,6 +176,7 @@ def test_aborted_context(aio):
         with pytest.raises(grpc.RpcError) as e:
             client.Execute(DummyRequest(input="error"))
         assert e.value.code() == grpc.StatusCode.RESOURCE_EXHAUSTED
+        assert re.fullmatch(r"resource exhausted", e.value.details())
 
 
 def test_override_with_ok():


### PR DESCRIPTION
This PR is just some minor tweaks.

`NoReturn` is a clearer return type for functions that are supposed to raise
https://docs.python.org/3/library/typing.html#typing.NoReturn

Added the code change from #43 to the async version as well. The test passes without it so I assume something in the actual gRPC library is making sure that we don't override the original status code, but I figured that we shouldn't call abort a second time anyway just to be safe.

Renamed a `request` parameter to `request_or_iterator` to match what it actually is and follow the same naming that is used elsewhere.